### PR TITLE
chore: redirects

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -1,0 +1,26 @@
+root: ./
+
+redirects:
+  help: support.md
+  ci-setup/github-actions/commit-data-for-github-actions: getting-started/ci-setup/github-actions/commit-data-for-github-actionscommit-data-for-github-actions.md
+  guides/load-balancing: guides/parallelization/load-balancing.md
+  integration-with-cypress/alternative-cypress-binaries: getting-started/cypress/integrating-with-cypress/alternative-cypress-binaries.md
+  integrations/bitbucket: resources/integrations/bitbucket.md
+  integration-with-cypress/cypress-cloud: getting-started/cypress/integrating-with-cypress/cypress-cloud.md
+  integration-with-playwright/currents-playwright: resources/reporters/currents-playwright.md
+  guides/fail-fast-strategy: guides/parallelization/fail-fast-strategy.md
+  tests/test-status: dashboard/tests/test-status.md
+  guides/playwright-tags: dashboard/tests/playwright-tags.md
+  integration-with-playwright/playwright-component-testing: getting-started/playwright/integration-with-playwright/playwright-component-testing.md
+  ci-setup/: getting-started/ci-setup.md
+  guides/pw-parallelization: guides/parallelization/pw-parallelization.md
+  getting-started/you-first-playwright-run: getting-started/playwright/you-first-playwright-run.md
+  administration/email-domain-based-access: dashboard/administration/email-domain-based-access.md
+  insights/runs-analytics: dashboard/insights-and-analytics.md
+  integration-with-cypress/cypress-cloud/migration-to-cypress-13: getting-started/cypress/integrating-with-cypress/cypress-cloud/migration-to-cypress-13.md
+  integration-with-playwright/troubleshooting: getting-started/playwright/troubleshooting-playwright.md
+  data-privacy/access-to-customer-data: resources/data-privacy/access-to-customer-data.md
+  data-privacy/data-retention: resources/data-privacy/data-retention.md
+  insights/test-suite-performance-explorer: dashboard/test-suite-performance-explorer.md
+  api/introduction: resources/api.md
+  insights/insights-and-analytics: dashboard/insights-and-analytics.md

--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -1,26 +1,5 @@
 root: ./
 
 redirects:
-  help: support.md
-  ci-setup/github-actions/commit-data-for-github-actions: getting-started/ci-setup/github-actions/commit-data-for-github-actionscommit-data-for-github-actions.md
-  guides/load-balancing: guides/parallelization/load-balancing.md
-  integration-with-cypress/alternative-cypress-binaries: getting-started/cypress/integrating-with-cypress/alternative-cypress-binaries.md
-  integrations/bitbucket: resources/integrations/bitbucket.md
-  integration-with-cypress/cypress-cloud: getting-started/cypress/integrating-with-cypress/cypress-cloud.md
-  integration-with-playwright/currents-playwright: resources/reporters/currents-playwright.md
-  guides/fail-fast-strategy: guides/parallelization/fail-fast-strategy.md
-  tests/test-status: dashboard/tests/test-status.md
-  guides/playwright-tags: dashboard/tests/playwright-tags.md
-  integration-with-playwright/playwright-component-testing: getting-started/playwright/integration-with-playwright/playwright-component-testing.md
-  ci-setup/: getting-started/ci-setup.md
-  guides/pw-parallelization: guides/parallelization/pw-parallelization.md
-  getting-started/you-first-playwright-run: getting-started/playwright/you-first-playwright-run.md
-  administration/email-domain-based-access: dashboard/administration/email-domain-based-access.md
+  ci-setup: getting-started/ci-setup/github-actions/commit-data-for-github-actionscommit-data-for-github-actions.md
   insights/runs-analytics: dashboard/insights-and-analytics.md
-  integration-with-cypress/cypress-cloud/migration-to-cypress-13: getting-started/cypress/integrating-with-cypress/cypress-cloud/migration-to-cypress-13.md
-  integration-with-playwright/troubleshooting: getting-started/playwright/troubleshooting-playwright.md
-  data-privacy/access-to-customer-data: resources/data-privacy/access-to-customer-data.md
-  data-privacy/data-retention: resources/data-privacy/data-retention.md
-  insights/test-suite-performance-explorer: dashboard/test-suite-performance-explorer.md
-  api/introduction: resources/api.md
-  insights/insights-and-analytics: dashboard/insights-and-analytics.md


### PR DESCRIPTION
## Summary

Creates the needed redirects for the changes on the docs navigation.

Preview: https://docs.currents.dev/~/changes/pyOcHiiE68OLDWMzYbOM

Note: We won't be able to test the redirects in the preview above, only after merging both changes. 