### PR TITLE
Standardize API resource frontmatter descriptions

### DIFF
--- a/resources/api/api-resources/README.md
+++ b/resources/api/api-resources/README.md
@@ -1,5 +1,5 @@
 ---
-description: Cypress tests API Reference - list of available resources
+description: API Reference - list of available resources
 ---
 
 # API Resources

--- a/resources/api/api-resources/spec-files.md
+++ b/resources/api/api-resources/spec-files.md
@@ -1,5 +1,5 @@
 ---
-description: API Reference - Spec Files Explorer
+description: API Reference - Spec Files resource
 ---
 
 # Spec Files Explorer - API

--- a/resources/api/api-resources/test-signature.md
+++ b/resources/api/api-resources/test-signature.md
@@ -1,5 +1,5 @@
 ---
-description: API Reference - Gets a test signature
+description: API Reference - Test Signature resource
 ---
 
 # Test Signature


### PR DESCRIPTION
- Update spec-files.md: "Spec Files Explorer" -> "Spec Files resource"
- Update test-signature.md: "Gets a test signature" -> "Test Signature resource"
- Update api-resources/README.md: Remove "Cypress tests" prefix for framework neutrality

All API resources now follow consistent "API Reference - [Resource Name] resource" pattern for better documentation coherence and professional appearance.

🤖 Generated with [Claude Code](https://claude.ai/code)