### PR TITLE
Generalize Cypress-specific terminology to generic test runner terms

### DIFF
--- a/resources/api/api-resources/instances.md
+++ b/resources/api/api-resources/instances.md
@@ -21,7 +21,7 @@ Asset URLs listed in the responses (videos, screenshots) are signed URLs that ar
 | instanceId<mark style="color:red;">\*</mark> | string | Instance ID |
 
 {% hint style="warning" %}
-The output is different for Cypress and Playwright results
+The output is different for different test runners
 {% endhint %}
 
 {% tabs %}
@@ -40,9 +40,9 @@ The output is different for Cypress and Playwright results
         "instanceId": "bf89e79f-af2a-43cb-afba-2575e567f103",
         // spec file path
         "spec": "cypress/integration/orchestration_100.spec.js",
-        // cypress runner version used to create the instance
+        // test runner version used to create the instance
         "cypressVersion": "10.3.0",
-        // cypress runner id used to create the instance
+        // test runner id used to create the instance
         "machineId": "25574b7e-c7d0-4ea4-804a-c56304c03fe0",
         // Git Commit info
         "commit": {

--- a/resources/api/api-resources/runs.md
+++ b/resources/api/api-resources/runs.md
@@ -24,7 +24,7 @@ Asset URLs listed in the responses (videos, screenshots) are signed URLs that ar
 | runId<mark style="color:red;">\*</mark> | string | Run ID      |
 
 {% hint style="warning" %}
-Note: The output may vary between Cypress and Playwright runs.
+Note: The output may vary between different test runners.
 {% endhint %}
 
 {% tabs %}
@@ -39,7 +39,7 @@ Note: The output may vary between Cypress and Playwright runs.
         "status": "FAILED", // "FAILED" | "FAILING" | "PASSED" | "RUNNING"
         "createdAt": "2022-07-06T08:23:40.939Z", // run creation time
         "tags": ["tagA", "tagB"], // run tags
-        "cypressVersion": "9.5.4", // cypress runner version
+        "cypressVersion": "9.5.4", // test runner version
         // timeout details
         "timeout": { 
             "isTimeout": true, // whether the run timed out
@@ -99,11 +99,11 @@ Note: The output may vary between Cypress and Playwright runs.
                 "spec": "integration/api/external-api-call-tests.ts",
                 // Associated instance ID
                 "instanceId": "b5f95e95-726f-4a3b-9edc-6cc0b0eb85fd",
-                // Time when a cypress runner requested the spec file
+                // Time when the test runner requested the spec file
                 "claimedAt": "2022-07-06T08:37:58.317Z",
-                // Time when a cypress runner reported the results to the dashboard
+                // Time when the test runner reported the results to the dashboard
                 "completedAt": "2022-07-06T08:38:05.113Z",
-                // Cypress runner that requested the spec file 
+                // Test runner that requested the spec file 
                 "machineId": "327043fb-f9df-4611-9a5e-8a33bbba7247",
                 // The results of the instance associated with the spec file
                 "results": {


### PR DESCRIPTION
Replace Cypress-specific references with generic "test runner" terminology where the context is not explicitly about Cypress functionality. This makes the documentation more framework-agnostic while preserving technical accuracy.

Changes:
- "Cypress and Playwright runs" → "different test runners"
- "cypress runner" → "test runner" in comments and descriptions
- Preserved Cypress-specific elements:
  - API field names (cypressVersion)
  - Type enum values ("cypress")
  - Tab titles indicating specific examples
  - File paths and stack traces in response examples
  - Explicit Cypress functionality documentation

Files updated:
- runs.md: 4 references generalized
- instances.md: 3 references generalized

🤖 Generated with [Claude Code](https://claude.ai/code)