### PR TITLE
Improve asset URL note for better clarity and user guidance

### DIFF
--- a/resources/api/api-resources/instances.md
+++ b/resources/api/api-resources/instances.md
@@ -7,7 +7,7 @@ description: API Reference - Instance resource
 An instance is an object representing the results of a spec file execution. You can obtain a list of instances associated with a run from the [runs.md](runs.md "mention") API resource.
 
 {% hint style="info" %}
-Asset URLs listed in the responses (videos, screenshots) are signed URLs that are valid for 2h.
+Asset URLs in the response (videos, screenshots) are pre-signed URLs with a 2-hour expiration time. You must download or access these URLs within 2 hours of receiving the API response.
 {% endhint %}
 
 ## Get Instance

--- a/resources/api/api-resources/runs.md
+++ b/resources/api/api-resources/runs.md
@@ -10,7 +10,7 @@ description: API Reference - Runs resource
 * See [instances.md](instances.md "mention") API resource for fetching Instance objects by `instanceId`
 
 {% hint style="info" %}
-Asset URLs listed in the responses (videos, screenshots) are signed URLs that are valid for 2h.
+Asset URLs in the response (videos, screenshots) are pre-signed URLs with a 2-hour expiration time. You must download or access these URLs within 2 hours of receiving the API response.
 {% endhint %}
 
 ## Get Run


### PR DESCRIPTION
- Replace vague "signed URLs that are valid for 2h" with clear explanation
- Specify these are "pre-signed URLs with a 2-hour expiration time"
- Add actionable user guidance about downloading/accessing within timeframe
- Make the message more user-friendly and informative
- Maintain consistent wording across instances.md and runs.md

🤖 Generated with [Claude Code](https://claude.ai/code)