### PR TITLE
Add capping feature for extra usage in billing documentation

### DIFF
--- a/dashboard/administration/billing-and-usage.md
+++ b/dashboard/administration/billing-and-usage.md
@@ -70,6 +70,24 @@ At the end of the monthly cycle, the billing will include the additional usage r
 
 The cost for extra recordings ranges and depends on your plan. For detailed pricing information, please check our [**pricing page**](https://currents.dev/#pricing). If you have any questions or concerns, please don't hesitate to contact us via _support@currents.dev_ or our in-app support chat.
 
+### Capping Extra Usage
+
+If your organization uses an extra usage plan, you can cap how much usage beyond the plan limit is allowed before Currents stops recording new results.
+
+To configure it, go to **Billing & Usage** and enable **Limit extra usage**. Then set **Extra usage cap %**.
+
+The cap is calculated as a percentage of your plan limit:
+
+* `0%` means Currents will stop recording as soon as you go over the included plan limit.
+* `50%` means Currents will allow up to 50% extra usage beyond the plan limit before stopping recording.
+* Example: if your plan includes `10,000` tests or runs and the cap is `50%`, recording stops after `15,000` total tests or runs.
+
+When the cap is reached, your CI pipelines and test runners continue running, but Currents pauses recording until one of the following happens:
+
+* the current usage cycle resets
+* you increase or remove the cap
+* you upgrade your plan
+
 ### Legacy Plans
 
 Our legacy plans (created before April 2023) do not have extra usage enabled.


### PR DESCRIPTION
- Introduced a new section on capping extra usage for organizations using an extra usage plan.
- Explained how to configure the cap, including percentage calculations and implications for recording.
- Clarified the behavior of Currents when the cap is reached, ensuring users understand the limits and options available.

These updates improve the clarity of billing and usage management for users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the new "Capping Extra Usage" feature, explaining how to configure usage caps in Billing & Usage settings, calculate cap percentages relative to plan limits, and understand system behavior when caps are reached.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->