### PR TITLE
chore: update AI prompt to use CURRENTS_PROJECT_ID

### DIFF
--- a/getting-started/your-first-playwright-run.md
+++ b/getting-started/your-first-playwright-run.md
@@ -59,7 +59,7 @@ import { CurrentsConfig } from "@currents/playwright";
 
 const config: CurrentsConfig = {
   recordKey: process.env.CURRENTS_RECORD_KEY!,
-  projectId: "iDxgqa"
+  projectId: process.env.CURRENTS_PROJECT_ID!,
 };
 
 export default config;


### PR DESCRIPTION
## Summary

Update the AI prompt to use `projectId` environment variable instead of hardcoded value.