### PR TITLE
docs: Document CURRENTS_CI_URL environment variable (ENG-510)

### DIFF
--- a/dashboard/runs/run-details.md
+++ b/dashboard/runs/run-details.md
@@ -43,3 +43,4 @@ Currents collects additional information about the CI environment:
 | Browser / Project    | Cypress tests browser or Playwright Project                                   |
 | Author               | Git commit author                                                             |
 | CI Build ID          | [ci-build-id.md](../../guides/parallelization-guide/ci-build-id.md "mention") |
+| CI Provider Link     | Auto-detected or custom CI job/run URL. Set `CURRENTS_CI_URL` to override. See [configuration.md](../reporters/currents-playwright/configuration.md "mention") |

--- a/getting-started/ci-setup/gitlab/custom-docker-runners.md
+++ b/getting-started/ci-setup/gitlab/custom-docker-runners.md
@@ -30,3 +30,19 @@ COMMIT_INFO_REMOTE=$CI_REPOSITORY_URL
 ```
 
 Adding these environment variables to your `.yml` file will allow your custom docker runner to report the correct information to Currents and have all the available information in the dashboard to use it as a usual Gitlab CI/CD tests execution.
+
+## Fallback: Using CURRENTS_CI_URL
+
+If your GitLab environment variables are not forwarded to the Docker container and auto-detection fails, you can explicitly provide the CI URL using the `CURRENTS_CI_URL` environment variable:
+
+```
+CURRENTS_CI_URL=$CI_JOB_URL
+```
+
+Or for GitLab pipelines:
+
+```
+CURRENTS_CI_URL=$CI_PIPELINE_URL
+```
+
+This ensures the run link in the Currents Dashboard points back to the correct GitLab job or pipeline. See [configuration.md](../../../resources/reporters/currents-playwright/configuration.md "mention") for more details on `CURRENTS_CI_URL`.

--- a/guides/troubleshooting-playwright.md
+++ b/guides/troubleshooting-playwright.md
@@ -111,3 +111,35 @@ npx playwright test ...
 When enabled, the debug logs will be uploaded to Currents servers and a confirmation message will be shown after the run's completion, for example:
 
 <figure><img src="../../.gitbook/assets/currents-2023-12-11-15.56.04@2x.png" alt=""><figcaption><p>Remote debug logs notification example</p></figcaption></figure>
+
+## CI Link Issues
+
+### Problem: CI link is missing or incorrect in the dashboard
+
+Currents displays a link to the CI job/run where the tests were executed. If this link is missing or incorrect:
+
+**Possible causes:**
+
+1. **Auto-detection failed** — Your CI provider environment variables are not available in the test environment (e.g., inside a Docker container, custom runner, or self-hosted CI)
+2. **Custom CI system** — Your CI provider is not automatically recognized by Currents
+3. **URL override needed** — You need to manually specify the CI URL
+
+**Solution:**
+
+Set the `CURRENTS_CI_URL` environment variable to provide the correct CI job/run URL:
+
+```bash
+# GitHub Actions example
+export CURRENTS_CI_URL="https://github.com/my-org/my-repo/actions/runs/$GITHUB_RUN_ID"
+
+# GitLab CI example
+export CURRENTS_CI_URL="$CI_JOB_URL"
+
+# Jenkins example
+export CURRENTS_CI_URL="$BUILD_URL"
+
+# Custom CI system
+export CURRENTS_CI_URL="https://ci.mycompany.com/builds/run-123"
+```
+
+For more details on `CURRENTS_CI_URL`, see [configuration.md](../../resources/reporters/currents-playwright/configuration.md "mention").

--- a/resources/reporters/currents-playwright/configuration.md
+++ b/resources/reporters/currents-playwright/configuration.md
@@ -79,6 +79,29 @@ cmd /V /C "set CURRENTS_PROJECT_ID=PROJECT_ID // the projectId from https://app.
 {% endtab %}
 {% endtabs %}
 
+### Environment Variables
+
+The following are environment variables that affect the Currents reporter but are **not configuration properties** (i.e., they cannot be set via `CurrentsConfig`, `currents.config.ts`, or CLI flags).
+
+#### CURRENTS_CI_URL
+
+Optional environment variable that overrides or provides a CI job/run URL when the reporter creates a run on Currents.
+
+By default, Currents automatically detects and constructs the CI URL from environment variables specific to your CI provider (e.g., GitHub Actions, GitLab CI, CircleCI, Jenkins, etc.). Set `CURRENTS_CI_URL` to override this auto-detected URL or provide one when auto-detection is unavailable (e.g., in Docker containers, custom runners, or self-hosted CI).
+
+**Example:**
+
+```bash
+export CURRENTS_CI_URL="https://github.com/org/repo/actions/runs/123456789"
+npx playwright test --reporter=@currents/playwright
+```
+
+The URL is displayed in the [Currents Dashboard run details](../../../dashboard/runs/run-details.md "mention"), allowing quick navigation back to the CI job.
+
+{% hint style="info" %}
+Whitespace is automatically trimmed. If the value is empty or contains only whitespace, it is ignored.
+{% endhint %}
+
 ## Reference
 
 ### ciBuildId <mark style="color:yellow;">\*</mark>


### PR DESCRIPTION
## Summary

Add comprehensive documentation for the `CURRENTS_CI_URL` environment variable to the currents-readme repository.

## Changes

- Added `ciUrl` reference in `resources/reporters/currents-playwright/configuration.md` with examples, use cases, and cross-links
- Added CI Provider Link row to the metadata table in `dashboard/runs/run-details.md` following the existing pattern
- Added fallback guidance in `getting-started/ci-setup/gitlab/custom-docker-runners.md` for containerized environments
- Added troubleshooting section in `guides/troubleshooting-playwright.md` for missing or incorrect CI links

## What is CURRENTS_CI_URL?

This environment variable allows users to override or provide a custom CI provider URL when auto-detection fails. It takes precedence over auto-detected URLs and is useful for:
- Custom CI systems without built-in Currents support
- Self-hosted CI (Jenkins, GitLab self-managed, etc.)
- Docker containers where provider environment variables aren't forwarded
- URL customization when auto-detection produces incorrect links

## Related

- Linear ticket: ENG-510

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added CI Provider Link metadata to dashboard run details.
  * Added fallback guidance for GitLab custom Docker runners using the CURRENTS_CI_URL environment variable.
  * New "CI Link Issues" troubleshooting section for the Playwright guide with examples for GitHub Actions, GitLab CI, Jenkins, and custom CI.
  * Documented the CURRENTS_CI_URL configuration option and behavior (trimming/empty handling).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/currents-dev/currents-readme/pull/43?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->