### PR TITLE
docs: document ciUrl as a configuration option [ENG-561]

### DIFF
--- a/resources/reporters/currents-playwright/configuration.md
+++ b/resources/reporters/currents-playwright/configuration.md
@@ -79,29 +79,6 @@ cmd /V /C "set CURRENTS_PROJECT_ID=PROJECT_ID // the projectId from https://app.
 {% endtab %}
 {% endtabs %}
 
-### Environment Variables
-
-The following are environment variables that affect the Currents reporter but are **not configuration properties** (i.e., they cannot be set via `CurrentsConfig`, `currents.config.ts`, or CLI flags).
-
-#### CURRENTS_CI_URL
-
-Optional environment variable that overrides or provides a CI job/run URL when the reporter creates a run on Currents.
-
-By default, Currents automatically detects and constructs the CI URL from environment variables specific to your CI provider (e.g., GitHub Actions, GitLab CI, CircleCI, Jenkins, etc.). Set `CURRENTS_CI_URL` to override this auto-detected URL or provide one when auto-detection is unavailable (e.g., in Docker containers, custom runners, or self-hosted CI).
-
-**Example:**
-
-```bash
-export CURRENTS_CI_URL="https://github.com/org/repo/actions/runs/123456789"
-npx playwright test --reporter=@currents/playwright
-```
-
-The URL is displayed in the [Currents Dashboard run details](../../../dashboard/runs/run-details.md "mention"), allowing quick navigation back to the CI job.
-
-{% hint style="info" %}
-Whitespace is automatically trimmed. If the value is empty or contains only whitespace, it is ignored.
-{% endhint %}
-
 ## Reference
 
 ### ciBuildId <mark style="color:yellow;">\*</mark>
@@ -225,6 +202,21 @@ File path for the JSON output summary. The TypeScript definition of the contents
 ```typescript
 import type { ExecutionJSONSummary } from '@currents/playwright'
 ```
+
+***
+
+### ciUrl
+
+* Type: `string`
+* Default: `undefined`
+* Environment variable: `CURRENTS_CI_URL`
+* Released in: `2.1.3`
+
+Overrides or provides the CI job/run URL shown in the [Currents Dashboard run details](../../../dashboard/runs/run-details.md "mention"). By default Currents auto-detects the CI URL from your provider's environment variables (GitHub Actions, GitLab CI, CircleCI, Jenkins, etc.). Set this to override the auto-detected URL, or to supply one when auto-detection is unavailable (e.g. Docker containers, custom runners, or self-hosted CI).
+
+{% hint style="info" %}
+Whitespace is automatically trimmed. If the value is empty or contains only whitespace, it is ignored.
+{% endhint %}
 
 ***
 


### PR DESCRIPTION
## Summary

`CURRENTS_CI_URL` is being promoted to a first-class **`ciUrl`** config option in `@currents/playwright` (settable via `currents.config.ts` and the `playwright.config.ts` reporter options, not just the env var). This updates the docs to match.

- **Removed** the standalone `### Environment Variables` → `#### CURRENTS_CI_URL` block, which described it as "**not a configuration property** (cannot be set via `CurrentsConfig`, `currents.config.ts`, or CLI flags)" — no longer true.
- **Added** a standard `### ciUrl` entry in the Reference section (placed after `outputFile`), matching the existing option format, with `Released in: 2.1.3`. The dashboard link and whitespace-trim note are preserved.

Other env-var usage docs (GitLab custom docker runners, troubleshooting, the run-details "CI Provider Link" row) are left as-is — the env var still works.

## Related

- Linear: ENG-561
- Code PR: currents-dev/currents-playwright#856

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized and enhanced `@currents/playwright` configuration reference documentation. Previously, environment variable information was in a separate section; now the `ciUrl` property is formally documented in the main configuration reference with comprehensive details including property type, default values, `CURRENTS_CI_URL` environment variable mapping, release version information, and whitespace-trimming behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/currents-dev/currents-readme/pull/44?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->