### PR TITLE
docs: environments for reporter config + Environments guide [ENG-546]

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -93,6 +93,7 @@
 - [Playwright Visual Testing](guides/playwright-visual-testing.md)
 - [Playwright Annotations](guides/playwright-annotations.md)
 - [Playwright Tags](guides/playwright-tags.md)
+- [Environments](guides/environments.md)
 - [Troubleshooting](guides/troubleshooting-playwright.md)
 
 ## Dashboard

--- a/guides/environments.md
+++ b/guides/environments.md
@@ -1,0 +1,156 @@
+---
+description: How to label and filter Currents runs by environment (e.g. staging, production)
+icon: layer-group
+---
+
+# Environments
+
+{% hint style="info" %}
+**Availability**
+
+* Setting an environment is available in [currents-playwright](../resources/reporters/currents-playwright/ "mention") version **2.1.0+**.
+* Filtering by environment in the Dashboard ([Run feed](../dashboard/runs/ "mention") + [Analytics](../dashboard/analytics/ "mention")) and the REST [API](https://app.gitbook.com/o/-MT4mUcrnbXWgd1xvl_x/s/lcxad7NaXT7D2V6owvHN/ "mention") is available for all projects.
+* `@currents/cmd`, `@currents/jest`, `@currents/node-test-reporter`, and `cypress-cloud` do not expose an `environment` option yet.
+{% endhint %}
+
+An **environment** is a label that describes _where_ or _under which conditions_ a test run was executed — for example `staging`, `production`, `preview`, or a CI matrix dimension such as a target region or device pool. Attaching an environment lets you compare and filter results across deployment targets without mixing them into the same metrics.
+
+Common uses:
+
+* Separate **staging** vs **production** smoke runs in the same project.
+* Compare stability of the same suite across regions (e.g. `us-east`, `eu-west`).
+* Slice [Analytics](../dashboard/analytics/ "mention") (run status, duration, flakiness, test results) by deployment target.
+
+## Environments vs. Tags
+
+Both classify runs, but they serve different purposes:
+
+| | Environment | [Tags](playwright-tags.md) |
+|---|---|---|
+| Cardinality | One value per run or per Playwright project | Many values per run/group/test |
+| Intent | _Where_ the tests ran (deployment target) | Arbitrary classification (feature, team, lifecycle) |
+| Source | Reporter config / project metadata | Test titles, project metadata, run config |
+
+A run can still end up with **multiple environments** when different Playwright projects within the same run set different values — see [How environments aggregate to a run](#how-environments-aggregate-to-a-run) below.
+
+## Setting the environment
+
+The environment is a **run-level** value, with an optional **per-project** override. It can be provided through any of the standard [configuration sources](../resources/reporters/currents-playwright/configuration.md).
+
+### `currents.config.ts`
+
+```typescript
+import type { CurrentsConfig } from "@currents/playwright";
+
+const config: CurrentsConfig = {
+  recordKey: process.env.CURRENTS_RECORD_KEY ?? "",
+  projectId: process.env.CURRENTS_PROJECT_ID ?? "",
+  environment: process.env.DEPLOY_ENV ?? "staging",
+};
+
+export default config;
+```
+
+### `CURRENTS_ENVIRONMENT` environment variable
+
+```bash
+CURRENTS_ENVIRONMENT=production npx playwright test
+```
+
+### `--pwc-environment` CLI option
+
+Supported by `pwc`, `pwc-p discover`, and `pwc-p run`:
+
+```bash
+npx pwc --pwc-environment staging
+```
+
+### Inline reporter option
+
+```typescript
+// playwright.config.ts
+import { currentsReporter } from "@currents/playwright";
+
+export default defineConfig({
+  reporter: [
+    currentsReporter({
+      recordKey: process.env.CURRENTS_RECORD_KEY,
+      projectId: process.env.CURRENTS_PROJECT_ID,
+      environment: "staging",
+    }),
+  ],
+});
+```
+
+### Per-project override
+
+Set `metadata.pwc.environment` on a Playwright project to override the run-level environment for that project only:
+
+```typescript
+// playwright.config.ts
+export default defineConfig({
+  projects: [
+    {
+      name: "chromium",
+      metadata: { pwc: { environment: "staging" } }, // 👈 per-project
+      use: { ...devices["Desktop Chrome"] },
+    },
+    {
+      name: "firefox",
+      metadata: { pwc: { environment: "production" } }, // 👈 per-project
+      use: { ...devices["Desktop Firefox"] },
+    },
+  ],
+});
+```
+
+### Precedence of configuration options
+
+When the environment is defined in more than one place, Currents resolves the value as follows (highest priority first):
+
+* **Per-project** `projects[].metadata.pwc.environment`, if set for the project; otherwise the run-level value:
+  * `CURRENTS_ENVIRONMENT` environment variable, if provided; otherwise
+  * `--pwc-environment` CLI option, if provided; otherwise
+  * `environment` from the inline reporter options in `playwright.config.ts`; otherwise
+  * `environment` from `currents.config.ts`; otherwise
+  * no environment is attached.
+
+## How environments aggregate to a run
+
+The environment is resolved **per Playwright project** and attached to the corresponding group when results are reported. At the run level, Currents collects the distinct environments from all groups into a list.
+
+For the per-project example above, the resulting run is associated with **both** `staging` and `production`, and shows up when filtering by either value:
+
+| Item | Environment |
+|---|---|
+| Run | `staging`, `production` |
+| Group `chromium` | `staging` |
+| Group `firefox` | `production` |
+
+If every project shares the same value (or you only set a run-level value), the run is associated with that single environment.
+
+## Filtering in the Dashboard
+
+Once runs carry an environment, an **Environment** filter is available in the [Run feed](../dashboard/runs/ "mention") and across [Analytics](../dashboard/analytics/ "mention") charts (run status, run duration, run completion, run size, test results, and flakiness). Selecting one or more environments narrows every metric on the page to runs that ran in those environments.
+
+## Filtering via the REST API
+
+Both the runs and insights endpoints accept an `environments[]` query parameter (repeat it to pass multiple values). Runs that match **any** of the supplied environments are returned.
+
+{% tabs %}
+{% tab title="Runs" %}
+```bash
+curl "https://api.currents.dev/v1/projects/PROJECT_ID/runs?environments[]=staging&environments[]=production" \
+  -H "Authorization: Bearer API_KEY_HERE"
+```
+{% endtab %}
+
+{% tab title="Insights" %}
+```bash
+curl "https://api.currents.dev/v1/projects/PROJECT_ID/insights?date_start=2026-01-01T00:00:00Z&date_end=2026-01-31T23:59:59Z&environments[]=staging" \
+  -H "Authorization: Bearer API_KEY_HERE"
+```
+{% endtab %}
+{% endtabs %}
+
+See the [API](https://app.gitbook.com/o/-MT4mUcrnbXWgd1xvl_x/s/lcxad7NaXT7D2V6owvHN/ "mention") reference for the full list of query parameters.

--- a/resources/reporters/currents-playwright/configuration.md
+++ b/resources/reporters/currents-playwright/configuration.md
@@ -144,6 +144,18 @@ Tags added to the test run metadata. See [playwright-tags.md](../../../guides/pl
 
 ***
 
+### environment
+
+* Type: `string`
+* Default: `undefined`
+* Environment variable: `CURRENTS_ENVIRONMENT`
+* CLI option: `--pwc-environment`
+* Released in: `2.1.0`
+
+Run-level environment label (e.g. `staging`, `production`) attached to the recorded run for filtering and analytics. Override it per Playwright project with `projects[].metadata.pwc.environment` in `playwright.config.ts`. See [environments.md](../../../guides/environments.md "mention").
+
+***
+
 ### removeTitleTags
 
 * Type: `boolean`


### PR DESCRIPTION
## Summary

Documents the **environment** feature ([ENG-546](https://linear.app/currents-dev/issue/ENG-546) / currents-dev/currents#2927) — labelling runs by environment (e.g. `staging`, `production`) and filtering by it.

### Changes
- **Reporter configuration** (`resources/reporters/currents-playwright/configuration.md`): new `environment` reference entry — type, default, `CURRENTS_ENVIRONMENT` env var, `--pwc-environment` CLI option, per-project override, and "Released in: 2.1.0".
- **New guide** (`guides/environments.md`): what an environment is, environments vs. tags, all the ways to set it (config file / env var / CLI / inline reporter / per-project `metadata.pwc.environment`), precedence, run-level aggregation, Dashboard filtering (Run feed + Analytics), and REST API examples (`environments[]` on `/runs` and `/insights`).
- **Navigation** (`SUMMARY.md`): linked the guide under Guides, after Playwright Tags.

### Verified against source
- `@currents/playwright` `CurrentsConfig.environment?: string`, env var `CURRENTS_ENVIRONMENT`, CLI `--pwc-environment` (`pwc`, `pwc-p discover/run`), per-project override `projects[].metadata.pwc.environment`; resolved per Playwright project and aggregated to a run-level `environments[]`. Introduced in **v2.1.0** (2026-05-22).
- `@currents/cmd`, `@currents/jest`, `@currents/node-test-reporter`, and `cypress-cloud` do **not** expose an `environment` option yet — called out in the guide.

> Note: no screenshots added (can't add binary assets here). Worth adding a dashboard screenshot of the Environment filter later to match the Tags guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `environment` configuration property to label test runs for filtering and analytics across Dashboard and REST API

* **Documentation**
  * New comprehensive guide documenting environment configuration, source precedence, and filtering capabilities
  * Updated configuration reference with `environment` property including CLI and environment variable options

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/currents-dev/currents-readme/pull/45?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->