### PR TITLE
fix: mention enterprise subscription for SSO

### DIFF
--- a/dashboard/administration/sso-saml2.0/README.md
+++ b/dashboard/administration/sso-saml2.0/README.md
@@ -15,7 +15,7 @@ Currents supports SSO integration via SAML 2.0, including JIT provisioning and S
 
 Please note that there are certain limitations to Currents SSO integration.
 
-* SSO integration is only available for customers with an **active subscription.**
+* SSO integration is only available for customers with an **active Enterprise subscription.**
 * Enabling SSO will for **all the team members.**
 * Follow the guide on enabling [idp-initiated-sessions.md](idp-initiated-sessions.md "mention")
 * Follow the guides on enabling [scim-user-provisioning.md](scim-user-provisioning.md "mention")

--- a/dashboard/administration/sso-saml2.0/jumpcloud/jumpcloud-user-provisioning.md
+++ b/dashboard/administration/sso-saml2.0/jumpcloud/jumpcloud-user-provisioning.md
@@ -15,7 +15,7 @@ For more information on the listed features, visit the [JumpCloud Support Page](
 
 ## Requirements <a href="#requirements" id="requirements"></a>
 
-Provisioning is available for customers with an active subscription.
+Provisioning is available for customers with an active Enterprise subscription.
 
 In order to setup provisioning you first need to:
 

--- a/dashboard/administration/sso-saml2.0/okta/README.md
+++ b/dashboard/administration/sso-saml2.0/okta/README.md
@@ -6,7 +6,7 @@ description: Setting up SAML2.0 SSO with Okta as an IdP - Currents SSO
 
 ### Prerequisites
 
-SAML as the SSO mode with provisioning is available for customers with an active subscription. Please follow the guide below to enable the integration and provide the necessary details to Currents support team.
+SAML as the SSO mode with provisioning is available for customers with an active Enterprise subscription. Please follow the guide below to enable the integration and provide the necessary details to Currents support team.
 
 {% hint style="info" %}
 **Please note**

--- a/dashboard/administration/sso-saml2.0/okta/okta-user-provisioning.md
+++ b/dashboard/administration/sso-saml2.0/okta/okta-user-provisioning.md
@@ -21,7 +21,7 @@ For more information on the listed features, visit the [Okta Glossary](https://h
 
 ### Requirements
 
-Provisioning is available for customers with an active subscription.
+Provisioning is available for customers with an active Enterprise subscription.
 
 In order to setup provisioning you first need to:
 


### PR DESCRIPTION
The current copy for SSO requirements is confusing some existing customers as it only mentions "active subscription" but in our pricing we mention that SSO is only for enterprise subscriptions.