### PR TITLE
[ENG-703] fix: include slack app requirements explanation

### DIFF
--- a/resources/integrations/slack/slack-app.md
+++ b/resources/integrations/slack/slack-app.md
@@ -16,6 +16,34 @@ Integrate Slack with Currents to receive real-time Playwright test notifications
 
 The integration supports organization-level installation, per-project configuration, multiple notification destinations, and advanced filtering options.
 
+## Requirements
+
+Before installing the Currents Slack App, the installation must be performed by a user with the correct administrator permissions in Slack. The required role depends on how the Slack account is structured:
+
+| Slack setup                                    | Who must install the app                                                                   |
+| ---------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| **Single workspace**                           | A **Workspace Owner** or **Workspace Admin**                                               |
+| **Enterprise Grid (multiple workspaces / org)** | An **Org Owner** or **Org Admin** (workspace-level admins are not sufficient on their own) |
+
+{% hint style="warning" %}
+**The app must be installed by an Org Admin when the Slack account belongs to an Enterprise Grid organization.**
+
+If a workspace-level admin installs the app while the workspace is part of a larger Slack organization, the installation may appear to succeed and Currents will store the access token, but Slack can later invalidate that token. When this happens, Currents receives an [`account_inactive`](https://docs.slack.dev/reference/methods/admin.apps.uninstall/#errors) error from the Slack API and notifications silently stop working.
+
+This occurs because, in an Enterprise Grid organization, apps are managed and approved at the org level. Tokens tied to a workspace-only installation can be deactivated when the installation is not authorized by an Org Owner/Admin. See Slack's documentation on [managing apps in an Enterprise organization](https://slack.com/help/articles/360000281563-Manage-apps-in-an-Enterprise-organization) and [org-level app policies](https://slack.com/help/articles/360038559694-Set-organisation-level-policies-for-apps) for details.
+{% endhint %}
+
+### Installation checklist
+
+1. Determine whether the Slack account is a single workspace or part of an **Enterprise Grid** organization. A Slack administrator can confirm this if it's unclear.
+2. For a single workspace, the Currents Slack App must be installed by a **Workspace Owner/Admin**.
+3. For an Enterprise Grid organization, an **Org Owner/Admin** must perform the installation (or approve and complete it). A workspace-level admin alone is not enough.
+4. If the app was already installed and notifications stopped working with an `account_inactive` error, the integration should be **disconnected** and reinstalled by an Org Owner/Admin. Reinstalling generates a new, valid token.
+
+{% hint style="info" %}
+The `account_inactive` error generally means the stored bot token is no longer valid - typically because the app was uninstalled or the installation was not authorized at the right level. The fix is to reinstall the app with an account that has the required permissions. See Slack's note on [deactivated members' apps and integrations](https://slack.com/help/articles/360000446446-Manage-deactivated-members-apps-and-integrations).
+{% endhint %}
+
 ## Installation
 
 ### Connecting Slack to Your Organization
@@ -309,6 +337,13 @@ Check the following:
 3. **Notification mode** - If set to "Only on failures", passing runs won't trigger notifications
 4. **Filters** - Check if any tag or branch filters are excluding your runs
 5. **Mention rules** - Ensure conditions match your test properties
+6. **Installation permissions** - If notifications stopped entirely, the Slack token may have been invalidated (`account_inactive`). See [Why did notifications stop with an `account_inactive` error?](#why-did-notifications-stop-with-an-account_inactive-error)
+
+### Why did notifications stop with an `account_inactive` error?
+
+This usually means the Slack access token was invalidated because the app was installed without the required administrator permissions. In an Enterprise Grid organization, apps must be installed (or approved) by an **Org Owner/Admin** - a workspace-level admin alone is not sufficient, and Slack may later deactivate that installation's token.
+
+The fix is to [disconnect](#disconnect-slack) the integration and reinstall it with an Org Owner/Admin (or a Workspace Owner/Admin for single-workspace accounts). See [Requirements](#requirements) for the full breakdown.
 
 ### Can I use both annotation mentions and UI rules?
 


### PR DESCRIPTION
# PR: Slack App requirements section

## What changed
Added a **Requirements** section to `resources/integrations/slack/slack-app.md`.

## Why
A customer's workspace-level admin installed the Slack App while the workspace was part of an Enterprise Grid org. The token saved but later failed with `account_inactive`, silently breaking notifications. Reinstalling as an Org Admin fixed it.

## Details
- New **Requirements** section (before Installation) with a role table: single workspace → Workspace Owner/Admin; Enterprise Grid → Org Owner/Admin.
- Warning hint explaining the `account_inactive` failure mode and root cause (org-level app management/approval).
- Installation checklist + remediation (disconnect & reinstall with the right admin).
- New FAQ entry, cross-linked from the existing "Why am I not receiving notifications?" checklist.
- All added copy is written in third person (no "you"/"your").

## References cited
- [Manage apps in an Enterprise organization](https://slack.com/help/articles/360000281563-Manage-apps-in-an-Enterprise-organization)
- [Set organization-level policies for apps](https://slack.com/help/articles/360038559694-Set-organisation-level-policies-for-apps)
- [Manage deactivated members' apps and integrations](https://slack.com/help/articles/360000446446-Manage-deactivated-members-apps-and-integrations)
- [`account_inactive` error reference](https://docs.slack.dev/reference/methods/admin.apps.uninstall/#errors)

## Note
Slack's docs attribute `account_inactive` broadly (uninstalled app / deactivated installer / wrong install level) rather than naming the org-vs-workspace-admin case verbatim. Framed as the most likely cause matching the incident.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Slack App integration requirements section specifying installer permissions for single-workspace and Enterprise Grid organizations
  * Added warning about potential `account_inactive` token errors from incorrect authorization with recovery guidance
  * Added installation checklist and expanded FAQ with troubleshooting steps for reconnection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->