### PR TITLE
chore: use retain-on-failure defaults for Playwright trace and video

### DIFF
--- a/getting-started/ci-setup/playwright-harness.md
+++ b/getting-started/ci-setup/playwright-harness.md
@@ -49,8 +49,8 @@ import { defineConfig } from "@playwright/test";
 export default defineConfig({
   reporter: [currentsReporter()],
   use: {
-    trace: "on",
-    video: "on",
+    trace: "retain-on-failure-and-retries",
+    video: "retain-on-failure",
     screenshot: "on",
   },
   // ...projects, testDir, etc.

--- a/getting-started/your-first-playwright-run.md
+++ b/getting-started/your-first-playwright-run.md
@@ -34,8 +34,8 @@ Your task is to update Playwright setup to report test results to Currents.dev
   - enable traces, videos and screenshots by updating the "use" property, e.g.:
 
   use: {
-      trace: "on",
-      video: "on",
+      trace: "retain-on-failure-and-retries",
+      video: "retain-on-failure",
       screenshot: "on",
   }
 
@@ -123,8 +123,8 @@ Update `playwright.config.ts` so every recorded run includes traces, videos, and
 ```json
 use: {
     // ...
-    trace: "on",
-    video: "on",
+    trace: "retain-on-failure-and-retries",
+    video: "retain-on-failure",
     screenshot: "on",
 }
 ```

--- a/guides/playwright-visual-testing.md
+++ b/guides/playwright-visual-testing.md
@@ -63,7 +63,7 @@ const config: PlaywrightTestConfig = {
   ],
   use: {
     actionTimeout: 0,
-    trace: "on",
+    trace: "retain-on-failure-and-retries",
     video: "retain-on-failure",
     screenshot: "only-on-failure",
   },
@@ -130,7 +130,7 @@ const config: PlaywrightTestConfig = {
   ],
   use: {
     actionTimeout: 0,
-    trace: "on",
+    trace: "retain-on-failure-and-retries",
     video: "retain-on-failure",
     screenshot: "only-on-failure",
   },

--- a/resources/reporters/currents-playwright/README.md
+++ b/resources/reporters/currents-playwright/README.md
@@ -52,8 +52,8 @@ Enabled traces, videos and screenshots in `playwright.config.js|ts`
 ```javascript
 use: {
     // ...
-    trace: "on",
-    video: "on",
+    trace: "retain-on-failure-and-retries",
+    video: "retain-on-failure",
     screenshot: "on",
 }
 ```


### PR DESCRIPTION
## Summary

Update public documentation snippets to recommend Playwright artifact retention defaults instead of always-on recording.

- `trace: "on"` → `trace: "retain-on-failure-and-retries"`
- `video: "on"` → `video: "retain-on-failure"`
- `screenshot` settings unchanged

## Changes by layer

- **Getting started** (`getting-started/*`): First-run and CI harness setup guides.
- **Guides** (`guides/playwright-visual-testing.md`): Visual testing config examples.
- **Resources** (`resources/reporters/currents-playwright/README.md`): Reporter setup snippet.

## Why

Docs currently tell users to enable `trace: "on"` and `video: "on"`, which records artifacts for every test. Retention-on-failure is a better default for CI cost and storage while still surfacing artifacts when debugging failures.

## Review hints

- Docs-only change — verify snippet consistency with `currents` onboarding copy and `currents-playwright` reporter README.
- `guides/playwright-visual-testing.md` already used `video: "retain-on-failure"`; only `trace` was updated there.

## Test plan

- [ ] Preview updated docs pages in GitBook (or local preview) and confirm code blocks render correctly.
- [ ] Cross-check snippets match the configs in `currents` and `currents-playwright` PRs.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Playwright configuration examples across multiple guides to optimize artifact retention: trace artifacts now retained only on failures and test retries, video artifacts retained only on test failures. These selective retention policies reduce storage usage while preserving debugging visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->