### PR TITLE
docs: add orchestration.createTimeoutMs configuration [ENG-891]

### DIFF
--- a/resources/reporters/currents-playwright/configuration.md
+++ b/resources/reporters/currents-playwright/configuration.md
@@ -306,6 +306,34 @@ Batch size is the number of parallel lanes the orchestrator fills for the reques
 Defining this variable will override any project-level batch size/workers definition in `playwright.config.ts` (`workers`, `currentsBatchSize` per project). Available on `@currents/playwright` starting at version `1.14.0`.
 {% endhint %}
 
+<br>
+
+#### orchestration.createTimeoutMs
+
+* Type: `number`
+* Default: `60000` (60 seconds)
+* Environment variable: `CURRENTS_OR8N_CREATE_TIMEOUT_MS`
+* Released in: `2.5.0`
+
+Milliseconds to wait for orchestration session creation during `pwc-p run`. This timeout covers the discovery phase (`playwright test --list`) and Currents session creation. 
+
+For large test suites with thousands of spec files, the default 60-second timeout may be insufficient. Increase this value if you encounter `Failed to start orchestration within 60000ms` errors during orchestration startup.
+
+**Example:**
+
+```typescript
+// currents.config.ts
+export default {
+  orchestration: {
+    createTimeoutMs: 300000, // 5 minutes for large test suites
+  },
+};
+```
+
+{% hint style="info" %}
+This timeout only affects the initial orchestration session setup. It does not impact individual test execution timeouts or the `orchestration.pendingChildExitTimeoutMs` setting.
+{% endhint %}
+
 ***
 
 ### coverage

--- a/resources/reporters/currents-playwright/pwc-p-run.md
+++ b/resources/reporters/currents-playwright/pwc-p-run.md
@@ -77,6 +77,10 @@ Prevent reporting tags defined in the test title or by test annotations (default
 
 Sets the number of parallel lanes the orchestrator fills per machine (defaults to `auto`, derived from your Playwright `--workers`). It is **not** a hard limit on how many spec files a machine claims — see [Orchestration and Multiple Workers](../../../guides/ci-optimization/playwright-orchestration.md). See [#orchestration.batchsize](configuration.md#orchestration.batchsize "mention").
 
+### `--pwc-create-timeout-ms <milliseconds>`
+
+Milliseconds to wait for orchestration session creation during discovery and session setup (defaults to `60000`). Increase for large test suites that exceed the default timeout. See [#orchestration.createtimeoutms](configuration.md#orchestration.createtimeoutms "mention").
+
 ### `--pwc-reset-signal <SIGUSR1|SIGUSR2>`
 
 Specify a process signal to listen for to trigger a reset of the current in-progress tests. Only available on OS with POSIX signal support. See [#orchestration.resetsignal](configuration.md#orchestration.resetsignal "mention").


### PR DESCRIPTION


Introduced a new configuration option `orchestration.createTimeoutMs` to specify the timeout for orchestration session creation, with a default of 60 seconds. Updated the `pwc-p run` documentation to include the `--pwc-create-timeout-ms` command-line option, allowing users to adjust the timeout for large test suites. This change enhances clarity on managing orchestration timeouts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for configuring the orchestration session creation timeout.
  * Documented the `orchestration.createTimeoutMs` setting, including default value, environment variable, and version details.
  * Documented the `--pwc-create-timeout-ms <milliseconds>` option, clarifying it applies only to initial orchestration setup (not per-test timeouts).
  * Included a configuration example for increasing the timeout for larger test suites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->