### PR TITLE
docs: expand re-run only failed tests guide

### DIFF
--- a/guides/ci-optimization/re-run-only-failed-tests-sharded.md
+++ b/guides/ci-optimization/re-run-only-failed-tests-sharded.md
@@ -4,10 +4,49 @@ description: Re-run only failed tests when using native Playwright sharding
 
 # Re-run Only Failed Tests — Sharded runs
 
-Native Playwright sharding runs tests in parallel across a fixed set of jobs. On retry, each job should run only the tests that failed in the previous execution. The guides below show how to wire `--last-failed` into GitHub Actions, GitLab CI, and Jenkins—using the `playwright-last-failed` helper where needed.
+Native Playwright sharding runs tests in parallel across a fixed set of jobs. On retry, each job should run only the tests that failed in the previous execution.
 
-Step-by-step guides:
+{% hint style="info" %}
+Sharded reruns use **Re-run failed jobs** in the CI provider — not **Re-run all jobs**. See [#re-run-the-failed-jobs-only](re-run-only-failed-tests-sharded.md#re-run-the-failed-jobs-only "mention").
+{% endhint %}
+
+## How sharding changes `--last-failed`
+
+Each shard is an independent Playwright process with its own `.last-run.json`. A shard's file lists **only the tests that ran in that shard**, so:
+
+* Every shard needs its **own** cached copy of `.last-run.json` — keyed by shard index.
+* Shard 2 re-runs shard 2's failures. Shards never see each other's results, so there is nothing to merge.
+* Shard assignment must stay **stable between attempts**. Playwright distributes tests deterministically, so keep the shard total and the test files unchanged between the original run and the retry.
+
+## What the setup has to do
+
+Three things have to be true for a sharded rerun to work:
+
+1. **`.last-run.json` survives between attempts.** CI machines are ephemeral — the file must be cached (or fetched from Currents) and restored into the retried job.
+2. **The cache is scoped per shard and per attempt.** The key needs the shard index (each shard has a different file) and the run attempt (on GitHub Actions an existing cache key cannot be overwritten, so each retry must write a new entry).
+3. **`--last-failed` is passed conditionally.** The first attempt has no `.last-run.json` — passing `--last-failed` when the file is missing is not what you want on a clean run. The flag should only be added when a previous run's file was restored.
+
+Additionally, the file has to be saved **even when the job fails**, which is exactly the case that matters. On GitHub Actions this means using `actions/cache/save` with `if: always()`, since the combined `actions/cache` action skips its save step when the job fails.
+
+## Re-run the failed jobs only
+
+Use the CI provider's **Re-run failed jobs** (GitHub Actions) or **Retry failed jobs** (GitLab CI):
+
+* Shards that passed are not restarted.
+* Shards that failed re-run with only their own failed tests.
+
+**Re-run all jobs** would restart every shard, including the ones that passed — which defeats the purpose. This is the opposite of [orchestrated runs](re-run-only-failed-tests-orchestrated-v2.md "mention"), where **Rerun All Jobs** is the correct choice because Currents redistributes the failed tests across all available machines.
+
+## Choosing an approach
+
+<table><thead><tr><th width="220">Approach</th><th>When to use it</th></tr></thead><tbody><tr><td><a href="https://github.com/currents-dev/playwright-last-failed">playwright-last-failed</a> action</td><td>GitHub Actions. Handles the cache, the per-shard/per-attempt key, and the conditional flags, and outputs the flags to pass to Playwright.</td></tr><tr><td><a href="../../resources/reporters/currents-cmd/currents-cache.md">currents cache</a> with <code>--preset last-run</code></td><td>GitLab CI and other providers. Stores <code>.last-run.json</code> in Currents-managed storage and writes the shard and <code>--last-failed</code> flags to an env file.</td></tr><tr><td>Native CI cache</td><td>No extra tooling. You own the cache keys and the conditional flag logic — see the caveats above.</td></tr></tbody></table>
+
+Playwright also accepts `--last-failed-file <path>` (or `PLAYWRIGHT_LAST_RUN_OUTPUT_FILE`) to write the last-run file to an explicit path instead of the default `<outputDir>/.last-run.json`. This is useful with a native cache, where caching a stable path is simpler than depending on the internal `outputDir` layout. See [re-run-only-failed-tests.md](re-run-only-failed-tests.md "mention") for details.
+
+## Step-by-step guides
 
 * [**GitHub Actions**](../../getting-started/ci-setup/github-actions/re-run-failed-only-tests-sharded.md)
 * [**GitLab CI**](../../getting-started/ci-setup/gitlab/re-run-failed-only-tests.md#playwright-sharding)
 * [**Jenkins Pipeline**](../../getting-started/ci-setup/jenkins.md#using-last-failed-flag-with-shards-and-orchestration)
+
+See also the overview: [re-run-only-failed-tests.md](re-run-only-failed-tests.md "mention").

--- a/guides/ci-optimization/re-run-only-failed-tests-sharded.md
+++ b/guides/ci-optimization/re-run-only-failed-tests-sharded.md
@@ -20,13 +20,24 @@ Each shard is an independent Playwright process with its own `.last-run.json`. A
 
 ## What the setup has to do
 
-Three things have to be true for a sharded rerun to work:
+Four things have to be true for a sharded rerun to work:
 
 1. `.last-run.json` survives between attempts. CI machines are ephemeral — the file must be cached (or fetched from Currents) and restored into the retried job.
-2. The cache is scoped per shard and per attempt. The key needs the shard index (each shard has a different file) and the run attempt (on GitHub Actions an existing cache key cannot be overwritten, so each retry must write a new entry).
-3. `--last-failed` is passed conditionally. The first attempt has no `.last-run.json` — passing `--last-failed` when the file is missing is not what you want on a clean run. The flag should only be added when a previous run's file was restored.
+2. The save key is unique per shard and per attempt. It needs the shard index, because each shard has a different file, and the attempt number, because on GitHub Actions an existing cache key cannot be overwritten — each retry has to write a new entry.
+3. The restore key is a prefix that omits the attempt. This is the step that is easy to miss: a key containing the attempt number never hits on a retry, because that attempt has not written a cache yet. Restore has to fall back to a stable `run_id` + shard prefix so it picks up the most recent previous attempt.
+4. `--last-failed` is passed conditionally. The first attempt has no `.last-run.json` — passing `--last-failed` when the file is missing is not what you want on a clean run. Add the flag only when a previous attempt's file was actually restored.
 
-Additionally, the file has to be saved even when the job fails, which is exactly the case that matters. On GitHub Actions this means using `actions/cache/save` with `if: always()`, since the combined `actions/cache` action skips its save step when the job fails.
+On GitHub Actions, points 2 and 3 come out as a save key with `run_attempt` and a restore prefix without it:
+
+```yaml
+key: last-run-${{ github.run_id }}-${{ matrix.shard }}-${{ github.run_attempt }}
+restore-keys: |
+  last-run-${{ github.run_id }}-${{ matrix.shard }}-
+```
+
+Scoping the key to `run_id` also keeps a previous workflow's results from leaking into a fresh run.
+
+The file also has to be saved even when the job fails, which is the case that matters here. Use `actions/cache/save` with `if: always()` — the combined `actions/cache` action skips its save step when the job fails.
 
 ## Re-run the failed jobs only
 

--- a/guides/ci-optimization/re-run-only-failed-tests-sharded.md
+++ b/guides/ci-optimization/re-run-only-failed-tests-sharded.md
@@ -12,21 +12,21 @@ Sharded reruns use **Re-run failed jobs** in the CI provider — not **Re-run al
 
 ## How sharding changes `--last-failed`
 
-Each shard is an independent Playwright process with its own `.last-run.json`. A shard's file lists **only the tests that ran in that shard**, so:
+Each shard is an independent Playwright process with its own `.last-run.json`. A shard's file lists only the tests that ran in that shard, so:
 
-* Every shard needs its **own** cached copy of `.last-run.json` — keyed by shard index.
+* Every shard needs its own cached copy of `.last-run.json` — keyed by shard index.
 * Shard 2 re-runs shard 2's failures. Shards never see each other's results, so there is nothing to merge.
-* Shard assignment must stay **stable between attempts**. Playwright distributes tests deterministically, so keep the shard total and the test files unchanged between the original run and the retry.
+* Shard assignment must stay stable between attempts. Playwright distributes tests deterministically, so keep the shard total and the test files unchanged between the original run and the retry.
 
 ## What the setup has to do
 
 Three things have to be true for a sharded rerun to work:
 
-1. **`.last-run.json` survives between attempts.** CI machines are ephemeral — the file must be cached (or fetched from Currents) and restored into the retried job.
-2. **The cache is scoped per shard and per attempt.** The key needs the shard index (each shard has a different file) and the run attempt (on GitHub Actions an existing cache key cannot be overwritten, so each retry must write a new entry).
-3. **`--last-failed` is passed conditionally.** The first attempt has no `.last-run.json` — passing `--last-failed` when the file is missing is not what you want on a clean run. The flag should only be added when a previous run's file was restored.
+1. `.last-run.json` survives between attempts. CI machines are ephemeral — the file must be cached (or fetched from Currents) and restored into the retried job.
+2. The cache is scoped per shard and per attempt. The key needs the shard index (each shard has a different file) and the run attempt (on GitHub Actions an existing cache key cannot be overwritten, so each retry must write a new entry).
+3. `--last-failed` is passed conditionally. The first attempt has no `.last-run.json` — passing `--last-failed` when the file is missing is not what you want on a clean run. The flag should only be added when a previous run's file was restored.
 
-Additionally, the file has to be saved **even when the job fails**, which is exactly the case that matters. On GitHub Actions this means using `actions/cache/save` with `if: always()`, since the combined `actions/cache` action skips its save step when the job fails.
+Additionally, the file has to be saved even when the job fails, which is exactly the case that matters. On GitHub Actions this means using `actions/cache/save` with `if: always()`, since the combined `actions/cache` action skips its save step when the job fails.
 
 ## Re-run the failed jobs only
 

--- a/guides/ci-optimization/re-run-only-failed-tests.md
+++ b/guides/ci-optimization/re-run-only-failed-tests.md
@@ -26,7 +26,7 @@ Re-running failed tests is for the cases where a human fixed something between t
 
 Playwright records the outcome of each run in a `.last-run.json` file. On the next run, `--last-failed` reads that file and executes only the tests listed as failed.
 
-By default the file is written to `<outputDir>/.last-run.json` — inside the **first project's** `outputDir` (commonly `test-results/`). That default is the source of most CI problems: `outputDir` is wiped before each run, so the file has to be preserved outside of it between runs.
+By default the file is written to `<outputDir>/.last-run.json` — inside the first project's `outputDir` (commonly `test-results/`). That default is the source of most CI problems: `outputDir` is wiped before each run, so the file has to be preserved outside of it between runs.
 
 Newer Playwright versions accept `--last-failed-file <path>` (or the `PLAYWRIGHT_LAST_RUN_OUTPUT_FILE` environment variable) to write the file to an explicit location, instead of depending on the internal `outputDir` layout:
 
@@ -37,18 +37,18 @@ npx playwright test --last-failed --last-failed-file .last-run.json
 See the [Playwright CLI reference](https://playwright.dev/docs/test-cli) for the exact flag definition and your version's support.
 
 {% hint style="warning" %}
-Store the last-run file **outside** `test-results/` or any configured `outputDir` — those directories are deleted before tests start.
+Store the last-run file outside `test-results/` or any configured `outputDir` — those directories are deleted before tests start.
 {% endhint %}
 
 ## Why CI makes it harder
 
 Wiring `--last-failed` into CI requires solving a few problems that don't exist locally:
 
-* **The file must survive between runs.** CI machines are ephemeral, so `.last-run.json` has to be cached or fetched from an external source.
-* **Each shard has its own file.** With native `--shard` parallelism, the file records only the tests from that shard, so caching must be per-shard.
-* **Cache keys are immutable.** On GitHub Actions an existing key cannot be overwritten, so the retry attempt (`run_attempt`) has to be part of the key.
-* **The file must be saved even when the job fails** — which is exactly when it matters. On GitHub Actions this means `actions/cache/save` with `if: always()`, since the combined `actions/cache` action skips the save step on failure.
-* **The right re-run button matters.** The correct choice differs between sharded and orchestrated runs — see the guides below.
+* The file must survive between runs. CI machines are ephemeral, so `.last-run.json` has to be cached or fetched from an external source.
+* Each shard has its own file. With native `--shard` parallelism, the file records only the tests from that shard, so caching must be per-shard.
+* Cache keys are immutable. On GitHub Actions an existing key cannot be overwritten, so the retry attempt (`run_attempt`) has to be part of the key.
+* The file must be saved even when the job fails, which is exactly when it matters. On GitHub Actions this means `actions/cache/save` with `if: always()`, since the combined `actions/cache` action skips the save step on failure.
+* The right re-run button matters. The correct choice differs between sharded and orchestrated runs — see the guides below.
 
 The [`currents-dev/playwright-last-failed`](https://github.com/currents-dev/playwright-last-failed) action handles the caching, the per-shard keys, and the conditional flags for you, and outputs the flags to pass to Playwright.
 

--- a/guides/ci-optimization/re-run-only-failed-tests.md
+++ b/guides/ci-optimization/re-run-only-failed-tests.md
@@ -16,7 +16,43 @@ While this feature works well for local environments, using it in CI with Playwr
 
 We have created a set of tools that simplify rerunning only the failed Playwright tests in CI, including sharded parallel CI runs and runs created by Currents Orchestration.&#x20;
 
-Follow the guide that matches how tests are run in CI:
+## When to use it
 
-* [Sharded runs](re-run-only-failed-tests-sharded.md "mention") — fixed shard count and native Playwright `--shard` parallelism
-* [Orchestrated runs](re-run-only-failed-tests-orchestrated-v2.md "mention")
+`--last-failed` is not a replacement for [`retries`](https://playwright.dev/docs/test-retries). Retries handle flakiness automatically, within the same run, without human involvement.
+
+Re-running failed tests is for the cases where a human fixed something between the two runs and the test code did not change — a missing environment variable, a disabled feature flag, a dependency that was down, a service that had not finished deploying. Instead of re-running the whole suite to validate the fix, you re-run only the tests that failed.
+
+## How `--last-failed` works
+
+Playwright records the outcome of each run in a `.last-run.json` file. On the next run, `--last-failed` reads that file and executes only the tests listed as failed.
+
+By default the file is written to `<outputDir>/.last-run.json` — inside the **first project's** `outputDir` (commonly `test-results/`). That default is the source of most CI problems: `outputDir` is wiped before each run, so the file has to be preserved outside of it between runs.
+
+Newer Playwright versions accept `--last-failed-file <path>` (or the `PLAYWRIGHT_LAST_RUN_OUTPUT_FILE` environment variable) to write the file to an explicit location, instead of depending on the internal `outputDir` layout:
+
+```bash
+npx playwright test --last-failed --last-failed-file .last-run.json
+```
+
+See the [Playwright CLI reference](https://playwright.dev/docs/test-cli) for the exact flag definition and your version's support.
+
+{% hint style="warning" %}
+Store the last-run file **outside** `test-results/` or any configured `outputDir` — those directories are deleted before tests start.
+{% endhint %}
+
+## Why CI makes it harder
+
+Wiring `--last-failed` into CI requires solving a few problems that don't exist locally:
+
+* **The file must survive between runs.** CI machines are ephemeral, so `.last-run.json` has to be cached or fetched from an external source.
+* **Each shard has its own file.** With native `--shard` parallelism, the file records only the tests from that shard, so caching must be per-shard.
+* **Cache keys are immutable.** On GitHub Actions an existing key cannot be overwritten, so the retry attempt (`run_attempt`) has to be part of the key.
+* **The file must be saved even when the job fails** — which is exactly when it matters. On GitHub Actions this means `actions/cache/save` with `if: always()`, since the combined `actions/cache` action skips the save step on failure.
+* **The right re-run button matters.** The correct choice differs between sharded and orchestrated runs — see the guides below.
+
+The [`currents-dev/playwright-last-failed`](https://github.com/currents-dev/playwright-last-failed) action handles the caching, the per-shard keys, and the conditional flags for you, and outputs the flags to pass to Playwright.
+
+## Follow the guide that matches how tests are run in CI
+
+* [Sharded runs](re-run-only-failed-tests-sharded.md "mention") — fixed shard count and native Playwright `--shard` parallelism. Re-run with **Re-run failed jobs**, so passed shards are not restarted.
+* [Orchestrated runs](re-run-only-failed-tests-orchestrated-v2.md "mention") — Currents assigns the failed tests to all available machines. Re-run with **Rerun All Jobs**.

--- a/guides/ci-optimization/re-run-only-failed-tests.md
+++ b/guides/ci-optimization/re-run-only-failed-tests.md
@@ -46,7 +46,7 @@ Wiring `--last-failed` into CI requires solving a few problems that don't exist 
 
 * The file must survive between runs. CI machines are ephemeral, so `.last-run.json` has to be cached or fetched from an external source.
 * Each shard has its own file. With native `--shard` parallelism, the file records only the tests from that shard, so caching must be per-shard.
-* Cache keys are immutable. On GitHub Actions an existing key cannot be overwritten, so the retry attempt (`run_attempt`) has to be part of the key.
+* Cache keys are immutable. On GitHub Actions an existing key cannot be overwritten, so the retry attempt (`run_attempt`) has to be part of the key it saves under — and the restore step then has to fall back to a prefix without the attempt, or the retry will never find the previous attempt's file.
 * The file must be saved even when the job fails, which is exactly when it matters. On GitHub Actions this means `actions/cache/save` with `if: always()`, since the combined `actions/cache` action skips the save step on failure.
 * The right re-run button matters. The correct choice differs between sharded and orchestrated runs — see the guides below.
 


### PR DESCRIPTION
Improves `guides/ci-optimization/re-run-only-failed-tests.md`, drawing on [Playwright's New --last-failed-file Flag](https://currents.dev/posts/playwright-re-run-only-failed-tests). The overview was a short pointer page; it now explains the mechanics before handing off to the CI-specific guides.

## What's added

- **When to use it** — the retries vs `--last-failed` distinction. Retries handle flakiness automatically within a run; `--last-failed` is for when a human fixed something between runs (env var, feature flag, a service that hadn't finished deploying) and the test code didn't change.
- **How `--last-failed` works** — `.last-run.json`, and the fact that it defaults to the *first project's* `outputDir`, which is the root cause of most CI trouble since that directory is wiped before each run.
- **`--last-failed-file`** — the flag and `PLAYWRIGHT_LAST_RUN_OUTPUT_FILE`, with a warning to store the file outside `test-results/`.
- **Why CI makes it harder** — file survival across ephemeral machines, per-shard files, immutable cache keys needing `run_attempt`, and the `actions/cache/save` + `if: always()` requirement (the combined action skips saving on failure, which is exactly when you need it).
- **The re-run button distinction**, which the sub-guides each state but the overview never connected: **Re-run failed jobs** for sharded, **Rerun All Jobs** for orchestrated.

## Reviewer note: unverified version claim

The source article says `--last-failed-file` landed in **v1.61**, and I could not verify that. The flag is real and documented in the [CLI reference](https://playwright.dev/docs/test-cli) (`--last-failed-file <file>`, default `<outputDir>/.last-run.json`), but neither the [release notes](https://playwright.dev/docs/release-notes) nor the [v1.61.0 notes](https://github.com/microsoft/playwright/releases/tag/v1.61.0) mention it — v1.61.0's CLI changes list only `-G`, `fullConfig.argv`, and a few others. It may have shipped without a release-note entry.

So the guide says "Newer Playwright versions accept…" and links to the CLI reference rather than committing to a version. **If you know the actual version, that sentence is the one to tighten.**

## Deliberately out of scope

The article's native GitHub Actions caching recipe (cache key strategy, restore/save steps) is CI-specific and belongs in `getting-started/ci-setup/github-actions/re-run-failed-only-tests-sharded.md`, which today documents only the Currents action and has no vanilla-caching alternative. Worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NFGnaGwzxSy88fHHCo2Tvs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded the “re-run only failed tests” guide with clearer explanations of `--last-failed`, how `.last-run.json` is generated/reused, and when to prefer explicit output settings.
  * Expanded the sharded CI rerun guide with stronger guidance on using the correct CI rerun mode for failed jobs, handling per-shard `.last-run.json` persistence, and ensuring results are saved even when runs fail.
  * Updated and expanded strategy comparisons for different rerun approaches, including notes for orchestrated/sharded CI setups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->