### PR TITLE
[ENG-518] feat: add multiple explanations

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -136,6 +136,7 @@
   - [Suite Size](dashboard/analytics/suite-size.md)
 - [Administration](dashboard/administration/README.md)
   - [Manage Team](dashboard/administration/manage-team.md)
+  - [API Keys](dashboard/administration/api-keys.md)
   - [Email Domain Based Access](dashboard/administration/email-domain-based-access.md)
   - [SSO SAML2.0](dashboard/administration/sso-saml2.0/README.md)
     - [SAML2.0 Configuration](dashboard/administration/sso-saml2.0/saml2.0-configuration.md)

--- a/ai/mcp-server.md
+++ b/ai/mcp-server.md
@@ -87,3 +87,23 @@ Here are some examples of AI prompts:
 * "What were the top flaky tests in the last 30 days?
 * "What were the slowest specs in the last 7 days?"
 * "Please fix all my flaky tests"
+
+### Permissions & Security
+
+The MCP server authenticates with the configured `CURRENTS_API_KEY`, and **every operation is limited by that API key's permissions**. The server does not grant any access beyond what the key already allows.
+
+* When the server is configured with a **Read Only** API key, all write operations (for example deleting a run, creating a webhook, or changing an action) are rejected by the Currents API with an **HTTP 403 Forbidden** - regardless of which tools the MCP server exposes to the agent.
+* A **Read & Write** key allows the agent to perform write operations. A Read Only key is recommended when the agent only needs to read test results and analytics.
+
+A dedicated key with the appropriate permission should be created to restrict what an AI agent can do through the MCP server. See [api-keys.md](../dashboard/administration/api-keys.md "mention") for how to create and scope API keys.
+
+{% hint style="danger" %}
+**Beware of destructive, irrecoverable operations.** When used with a **Read & Write** key, the MCP server can perform permanent deletions with no confirmation step and no way to restore the data. Currently the irrecoverable tools are:
+
+* **`currents-delete-run`** - permanently deletes a run and all associated data (test results, test records, instances, and analytics). This cannot be undone.
+* **`currents-delete-webhook`** - permanently removes a webhook configuration.
+
+* **`currents-delete-action`** - permanently removes an action.
+
+Other write operations - such as `currents-cancel-run`, `currents-reset-run`, webhook and action creation/updates, and Jira issue creation/linking - are impactful but reversible. Grant a Read & Write key to an agent only when these capabilities are required.
+{% endhint %}

--- a/dashboard/administration/api-keys.md
+++ b/dashboard/administration/api-keys.md
@@ -1,6 +1,5 @@
 ---
 description: Create and manage API keys to access the Currents REST API, MCP server, and integrations
-icon: key
 ---
 
 # API Keys

--- a/dashboard/administration/api-keys.md
+++ b/dashboard/administration/api-keys.md
@@ -1,0 +1,54 @@
+---
+description: Create and manage API keys to access the Currents REST API, MCP server, and integrations
+icon: key
+---
+
+# API Keys
+
+API keys authenticate programmatic access to Currents - the [REST API](https://app.gitbook.com/o/-MT4mUcrnbXWgd1xvl_x/s/lcxad7NaXT7D2V6owvHN/), the [MCP Server](../../ai/mcp-server.md), the CLI tools, and other integrations. Every request is authorized against the permissions of the API key it carries, not the dashboard role of the user who created it.
+
+{% hint style="info" %}
+API keys are **organization-wide** credentials. They should be treated like passwords - stored in a secret manager and never committed to source control.
+{% endhint %}
+
+## Managing API Keys
+
+Only organization **Admins** can create or revoke API keys. **Actions Admin** and **Member** roles can view existing keys, while **Guest** users cannot. See [manage-team.md](manage-team.md "mention") for the full permissions matrix.
+
+To create a key:
+
+1. Navigate to **Organization → API Keys**
+2. Click **Create API Key**
+3. Set a **label** (used to identify the key in audit logs and notifications)
+4. Choose the key **permission** (see below)
+5. Copy the generated key - it is shown only once
+
+## API Key Permissions
+
+Each key is assigned one of two permission levels that govern what it can do across the entire organization:
+
+| Permission        | Access                                                                 |
+| ----------------- | --------------------------------------------------------------------- |
+| **Read Only**     | Read-only access to `GET` endpoints (runs, tests, analytics, metrics). |
+| **Read & Write**  | Full read access plus write operations (create, update, delete).       |
+
+Authorization is enforced **server-side at the REST API layer**. A **Read Only** key that attempts a write operation - deleting a run, creating a webhook, changing an action, or creating a Jira issue - is rejected with an **HTTP 403 Forbidden**, regardless of which client or tool issued the request.
+
+{% hint style="warning" %}
+**Legacy keys** created before permission levels were introduced default to **Read & Write** for backward compatibility. For read-only access, a new key with the **Read Only** permission should be created rather than reusing an older key.
+{% endhint %}
+
+### Scope
+
+API key permissions are **organization-wide**. A key applies to all projects and data in the organization exposed by the endpoints it can reach. There is currently no per-project, per-tool, or per-endpoint key scoping - only the Read Only vs Read & Write distinction.
+
+## Using API Keys
+
+The key is passed as a bearer token in the `Authorization` header:
+
+```bash
+curl https://api.currents.dev/v1/runs \
+-H "Authorization: Bearer API_KEY_HERE"
+```
+
+For MCP and integration setups, the key is provided through the relevant configuration (for example the `CURRENTS_API_KEY` environment variable). See the [MCP Server](../../ai/mcp-server.md) documentation for details.

--- a/resources/integrations/jira.md
+++ b/resources/integrations/jira.md
@@ -9,7 +9,7 @@ coverY: 0
 
 # Jira
 
-Currents integration with Jira allows your team to create and link test failure details directly from the Currents dashboard. Team members can create new or add comments to existing Jira issues with full context:
+Currents integration with Jira allows teams to create and link test failure details directly from the Currents dashboard. Team members can create new or add comments to existing Jira issues with full context:
 
 * error messages,
 * stack traces,
@@ -26,7 +26,7 @@ without leaving Currents, eliminating context switching.
 
 1. Enable Jira Integration in project settings
 2. Install Currents for Jira from Atlassian Marketplace
-3. Link your accounts with installation token
+3. Link the accounts with installation token
 
 See the [Setup Guide](jira/setup.md) for complete instructions.
 
@@ -40,3 +40,23 @@ See the [Usage Guide](jira/usage.md) for details.
 #### Limitations
 
 See [#limitations](jira/usage.md#limitations "mention")
+
+### Security & API Access
+
+The Jira integration is designed so that programmatic access - including through the [REST API](https://app.gitbook.com/o/-MT4mUcrnbXWgd1xvl_x/s/lcxad7NaXT7D2V6owvHN/) and the [MCP Server](../../ai/mcp-server.md) - never grants more capability than the dashboard itself:
+
+* **Strictly contained to dashboard functionality.** API and MCP access to Jira is limited to the same operations available in the Currents dashboard: listing Jira projects and issue types, and creating or linking issues. There are no additional or privileged Jira operations exposed through the API.
+* **Jira credentials are never disclosed.** The Jira access tokens used by the integration are stored encrypted and are never exposed through the API, the MCP server, or any response. Requests are proxied through Currents using the organization's configured Jira installation - clients never receive the underlying Jira API keys or tokens.
+* **Governed by Currents API key permissions.** Jira write operations (creating or linking issues) require a **Read & Write** [Currents API key](../../dashboard/administration/api-keys.md). A **Read Only** key can list Jira projects and issue types but cannot create or link issues (requests return HTTP 403).
+
+#### Requested Jira scopes
+
+The [Currents for Jira](https://marketplace.atlassian.com/apps/1238333) application requests the following Atlassian scopes, which apply to the organization integration as a whole (dashboard, REST API, and MCP alike):
+
+* `read:jira-work`
+* `read:jira-user`
+* `write:jira-work`
+* `manage:jira-project`
+* `read:app-system-token`
+
+The integration does not grant any Jira permissions beyond these, and the API cannot expand its own access beyond what the installed Jira app already permits.


### PR DESCRIPTION
## Summary

Documents Currents API key permissions and clarifies the security model for programmatic access (REST API, MCP server, and integrations), addressing common security-review concerns.

## Changes

- **New: `dashboard/administration/api-keys.md`** — Explains what API keys are, how to create/manage them (Organization → API Keys), who can manage vs. view them, and the two permission levels (**Read Only** vs **Read & Write**) with server-side 403 enforcement. Notes org-wide scope and legacy-key behavior. Added to `SUMMARY.md`.
- **`ai/mcp-server.md`** — Adds a *Permissions & Security* section clarifying that the MCP server is limited by the configured API key's permissions, with a link to the API Keys doc. Includes a warning listing the destructive, irrecoverable operations (`currents-delete-run`, `currents-delete-webhook`, `currents-delete-action`).
- **`resources/integrations/jira.md`** — Adds a *Security & API Access* section: API/MCP access is contained to dashboard functionality, Jira credentials are encrypted and never disclosed, writes require a Read & Write key, and lists the requested Atlassian scopes.

All added content uses third-person wording.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dashboard documentation for creating and managing organization-wide API keys.
  * Added MCP server security guidance, including permission-based access (with write restrictions) and warnings for irreversible destructive operations.
  * Added “API Keys” to the Administration documentation navigation.
* **Documentation**
  * Expanded Jira integration guidance with a new “Security & API Access” section, covering constrained capabilities, credential protection, required API key permissions for write operations, and requested Jira app scopes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->