### PR TITLE
docs: group billing pages under a single Billing category

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -52,3 +52,5 @@ redirects:
   projects/project-settings: dashboard/projects/project-settings.md
   projects/projects-summary-view: dashboard/projects/projects-summary-view.md
   projects/archive-and-unarchive-projects: dashboard/projects/archive-and-unarchive-projects.md
+  dashboard/billing-and-pricing: dashboard/billing/billing-and-pricing.md
+  dashboard/administration/billing-and-usage: dashboard/billing/billing-and-usage.md

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -147,8 +147,9 @@
     - [Okta](dashboard/administration/sso-saml2.0/okta/README.md)
       - [Okta User provisioning](dashboard/administration/sso-saml2.0/okta/okta-user-provisioning.md)
     - [Troubleshooting SSO](dashboard/administration/sso-saml2.0/troubleshooting-sso.md)
-  - [Billing & Usage](dashboard/administration/billing-and-usage.md)
-- [Billing & Pricing](dashboard/billing-and-pricing.md)
+- [Billing](dashboard/billing/README.md)
+  - [Billing & Pricing](dashboard/billing/billing-and-pricing.md)
+  - [Billing & Usage](dashboard/billing/billing-and-usage.md)
 
 ## Resources
 

--- a/dashboard/billing/README.md
+++ b/dashboard/billing/README.md
@@ -1,0 +1,5 @@
+---
+icon: credit-card
+---
+
+# Billing

--- a/dashboard/billing/billing-and-pricing.md
+++ b/dashboard/billing/billing-and-pricing.md
@@ -26,7 +26,7 @@ Skipped[^2] recordings do not count for billing purpose. Number of attempts or t
 
 #### Team Members
 
-Every non-guest account associated with your organization is considered a team member for billing purposes. Each plan has a predetermined limit of seats (Team Members). You can purchase additional seats, up to 30 seats total, using [billing-and-usage.md](administration/billing-and-usage.md "mention") section.
+Every non-guest account associated with your organization is considered a team member for billing purposes. Each plan has a predetermined limit of seats (Team Members). You can purchase additional seats, up to 30 seats total, using [billing-and-usage.md](billing-and-usage.md "mention") section.
 
 [Guest accounts](administration/manage-team.md) do not count toward the organization limit and can be invited without limits.&#x20;
 
@@ -38,7 +38,7 @@ For a ballpark estimate, count the number of `it` and `test` statements in your 
 
 `Test Recording Volume` = `it or test statements` x `CI runs per month`
 
-To have a more accurate estimation, create a free trial account and start sending the test results, after a couple of days use the [billing-and-usage.md](administration/billing-and-usage.md "mention") section to review your usage. Contact our team to extend your trial [hello@currents.dev](mailto:hello@currents.dev).
+To have a more accurate estimation, create a free trial account and start sending the test results, after a couple of days use the [billing-and-usage.md](billing-and-usage.md "mention") section to review your usage. Contact our team to extend your trial [hello@currents.dev](mailto:hello@currents.dev).
 
 ## Subscription Types
 
@@ -62,7 +62,7 @@ The usage cycle resets each month on the day of subscription creation.
 
 ### Extra Seats
 
-Each plan has a predetermined limit of seats (Team Members). You can purchase additional seats, up to 30 seats total, using [billing-and-usage.md](administration/billing-and-usage.md "mention") section.
+Each plan has a predetermined limit of seats (Team Members). You can purchase additional seats, up to 30 seats total, using [billing-and-usage.md](billing-and-usage.md "mention") section.
 
 If you need more seats please contact us at [hello@currents.dev](mailto:hello@currents.dev).
 
@@ -70,7 +70,7 @@ If you need more seats please contact us at [hello@currents.dev](mailto:hello@cu
 
 We will charge the Extra Usage fee for every additional 1K tests (or portion of it) at the end of usage cycle. The price for the extra usage unit depends on the plan and varies.
 
-When your organization start incurring Extra Usage fee Currents sends a period email notification to organization owners with an alert. Additionally, you can set up usage warning in [billing-and-usage.md](administration/billing-and-usage.md "mention") section of the dashboard.
+When your organization start incurring Extra Usage fee Currents sends a period email notification to organization owners with an alert. Additionally, you can set up usage warning in [billing-and-usage.md](billing-and-usage.md "mention") section of the dashboard.
 
 Depending on the Usage and Billing Cycle (see below) and payment method, we will charge the fee on Monthly, Quarterly or Annual Basis.
 
@@ -84,7 +84,7 @@ If your organization uses an extra usage plan, you can cap how much usage beyond
 
 To configure it, go to **Billing & Usage** and enable **Limit extra usage**. Then set **Extra usage cap %**.
 
-<figure><img src="../.gitbook/assets/CleanShot 2026-04-15 at 00.59.11@2x.png" alt=""><figcaption></figcaption></figure>
+<figure><img src="../../.gitbook/assets/CleanShot 2026-04-15 at 00.59.11@2x.png" alt=""><figcaption></figcaption></figure>
 
 The cap is calculated as a percentage of your plan limit:
 
@@ -156,7 +156,7 @@ Currents doesn't have a free plan.
 
 ### How can I track my usage?
 
-Use [billing-and-usage.md](administration/billing-and-usage.md "mention") section to setup usage warnings. Additionally, Currents will send an automated emails when you start incurring Extra Usage fees. Our Customer Success team will reach out to your organization admins if you consistently exceed your plan limits or incur significant charges with a recommendation to upgrade your plan.
+Use [billing-and-usage.md](billing-and-usage.md "mention") section to setup usage warnings. Additionally, Currents will send an automated emails when you start incurring Extra Usage fees. Our Customer Success team will reach out to your organization admins if you consistently exceed your plan limits or incur significant charges with a recommendation to upgrade your plan.
 
 ### Do you charge for data storage?
 

--- a/dashboard/billing/billing-and-usage.md
+++ b/dashboard/billing/billing-and-usage.md
@@ -56,7 +56,7 @@ If you click **Show Usage Details**, you can see a breakdown of all recorded tes
 * **Enterprise Plans:** An **annual usage cycle** is available, with monthly cycle is also supported.\
   The annual cycle is recommended for teams with **seasonal usage patterns** or **peaks in usage** during certain times of the year.
 
-More details on [billing-and-pricing.md](../billing-and-pricing.md "mention")
+More details on [billing-and-pricing.md](billing-and-pricing.md "mention")
 
 ### Extra Usage Plans
 
@@ -77,7 +77,7 @@ To limit how much extra usage can accrue, see [Usage Alerts and Spend Control](#
 The **Usage Alerts** section of **Billing & Usage** lets organization admins configure usage notifications and cap extra usage spend:
 
 * **Usage Alert Threshold %** — Currents sends an email to organization admins when usage exceeds this percentage of the plan limit. The default threshold is 90%.
-* **Limit extra usage** — stops recording new results when extra usage beyond the plan limit reaches a cap. The cap is set as **Extra usage cap %** — a percentage of the plan limit. For example, with a plan limit of 10,000 tests and a cap of 50%, recording stops after 15,000 tests. Setting the cap to 0% stops recording as soon as the plan limit is reached. See [Capping Extra Usage](../billing-and-pricing.md#capping-extra-usage) for details.
+* **Limit extra usage** — stops recording new results when extra usage beyond the plan limit reaches a cap. The cap is set as **Extra usage cap %** — a percentage of the plan limit. For example, with a plan limit of 10,000 tests and a cap of 50%, recording stops after 15,000 tests. Setting the cap to 0% stops recording as soon as the plan limit is reached. See [Capping Extra Usage](billing-and-pricing.md#capping-extra-usage) for details.
 
 When the cap is reached, Currents emails organization admins and pauses recording. CI pipelines and test runners keep running — Currents resumes recording when the usage cycle resets, the cap is increased or removed, or the plan is upgraded.
 


### PR DESCRIPTION
## What changed

Groups the two billing pages under a single **Billing** category in the Dashboard section:

- `dashboard/billing-and-pricing.md` → `dashboard/billing/billing-and-pricing.md`
- `dashboard/administration/billing-and-usage.md` → `dashboard/billing/billing-and-usage.md`
- New `dashboard/billing/README.md` category page (icon: credit-card, matching the Administration category style)

Previously Billing & Usage lived under Administration while Billing & Pricing was a standalone top-level Dashboard entry.

## Details

- SUMMARY.md: both pages nested under the new Billing entry; removed from their old locations.
- `.gitbook.yaml`: redirects added for both old URLs (`dashboard/billing-and-pricing`, `dashboard/administration/billing-and-usage`).
- Cross-links between the two pages updated to same-directory paths; image paths in billing-and-pricing.md adjusted for the new depth (`../` → `../../`). No other pages in the repo link to either file.

## Notes for review

- Stacked on #55 (base branch `docs/usage-alerts-spend-control`) because both PRs edit billing-and-usage.md. Merge #55 first, then retarget this PR to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VuKBfa3x4NVZfPFAsp2FWY
