### PR TITLE
docs: add AI section overview guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ As teams scale testing in CI, they need visibility into debugging traces, flakin
 [alternatives-to-currents.md](resources/reporters/alternatives-to-currents.md)
 {% endcontent-ref %}
 
+## Use Currents with AI
+
+Currents turns test failures into structured context that AI agents can act on - full errors, traces, historical results, and flakiness data - so an agent fixes a failing test from real evidence instead of a pasted error message. Debug interactively in your editor, hand failures to an agent from the dashboard, or build pipelines that auto-heal failing tests.
+
+<table><thead><tr><th width="280" data-type="content-ref">AI</th><th></th></tr></thead><tbody><tr><td><a href="ai/">ai</a></td><td>All the ways to connect AI agents to your test results.</td></tr><tr><td><a href="ai/ide-extension.md">ide-extension.md</a></td><td>Fix CI failures with AI without leaving your editor.</td></tr><tr><td><a href="ai/mcp-server.md">mcp-server.md</a></td><td>Let agents query runs, tests, and analytics on demand.</td></tr><tr><td><a href="ai/agent-skill-playwright-best-practices.md">agent-skill-playwright-best-practices.md</a></td><td>Expert Playwright knowledge for your AI agents.</td></tr></tbody></table>
+
 ## Explore
 
 Currents is much more than a reporter. Discover the full range of features and capabilities.
@@ -35,4 +41,4 @@ Currents is much more than a reporter. Discover the full range of features and c
 
 <table><thead><tr><th width="280" data-type="content-ref">Speeding up CI</th><th></th></tr></thead><tbody><tr><td><a href="guides/ci-optimization/">ci-optimization</a></td><td>Shorten pipelines without sacrificing coverage.</td></tr><tr><td><a href="guides/test-orchestration.md">test-orchestration.md</a></td><td>Distribute tests across CI jobs. Faster than Sharding.</td></tr></tbody></table>
 
-<table><thead><tr><th width="280" data-type="content-ref">AI &#x26; Automation</th><th></th></tr></thead><tbody><tr><td><a href="ai/mcp-server.md">mcp-server.md</a></td><td>Give AI agents access to test analytics and execution data.</td></tr><tr><td><a href="guides/currents-actions/">currents-actions</a></td><td>Automatically alert, skip or quarantine tests.</td></tr><tr><td><a href="dashboard/automated-reports.md">automated-reports.md</a></td><td>Proactively identify regressions.</td></tr><tr><td><a href="resources/integrations/">integrations</a></td><td>Integrate with issue tracking and collaboration tools.</td></tr></tbody></table>
+<table><thead><tr><th width="280" data-type="content-ref">Automation</th><th></th></tr></thead><tbody><tr><td><a href="guides/currents-actions/">currents-actions</a></td><td>Automatically alert, skip or quarantine tests.</td></tr><tr><td><a href="dashboard/automated-reports.md">automated-reports.md</a></td><td>Proactively identify regressions.</td></tr><tr><td><a href="resources/integrations/">integrations</a></td><td>Integrate with issue tracking and collaboration tools.</td></tr></tbody></table>

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -53,6 +53,7 @@
 
 ## AI
 
+- [Overview](ai/README.md)
 - [MCP Server](ai/mcp-server.md)
 - [Agent Skill: Playwright Best Practices](ai/agent-skill-playwright-best-practices.md "Playwright Skill")
 - [IDE Extension](ai/ide-extension.md)

--- a/ai/README.md
+++ b/ai/README.md
@@ -76,6 +76,12 @@ The [n8n integration](../resources/integrations/n8n.md) connects Currents to 1,3
 
 Combined with [HTTP webhooks](../resources/integrations/http-webhooks.md) as a trigger, this covers the fully autonomous end of the spectrum - no editor, no dashboard, just test results flowing into whatever process you define.
 
+## Coming up
+
+### Slack
+
+**Fix with AI** is coming to the [Slack integration](../resources/integrations/slack/README.md): failed-test notifications will include a Fix with AI button that opens one-click deep links to AI coding tools, plus a copyable prompt for everything else - prefilled with the same enriched failure context and MCP identifiers as the dashboard and IDE actions. A failure lands in your team channel, and anyone in the thread can route it to an agent without opening the dashboard first.
+
 ## Combining entry points
 
 These methods compose - most teams end up using several:

--- a/ai/README.md
+++ b/ai/README.md
@@ -1,0 +1,85 @@
+---
+description: >-
+  How to connect AI agents to Currents test results - MCP, IDE extension,
+  dashboard prompts, agent skills, and automation
+icon: sparkles
+---
+
+# Overview
+
+Currents captures everything about your test runs: errors, stack traces, traces, console and network logs, historical pass/fail data, flakiness rates, and performance metrics. This page is an overview of the ways to put that data in front of an AI agent - whether you are debugging interactively in your editor, triaging failures from the dashboard, or building autonomous troubleshooting pipelines.
+
+## Why context matters
+
+Pasting an error message into an AI chat is the least effective way to use an agent for test failures. The error message alone is missing most of what determines the right fix:
+
+* Is this test flaky, or did it just start failing? An agent that doesn't know the test's history will "fix" a flaky test by treating a symptom.
+* What was on the page when the assertion failed? Without the DOM state, the agent guesses why a locator didn't match.
+* Did other tests in the run fail for the same reason? A selector change that breaks 12 tests needs one fix, not 12.
+
+Currents post-processes test results on the server into a structured troubleshooting context that answers these questions:
+
+* Full error message, stack trace, and code frame (ANSI codes stripped)
+* An **error-context snapshot** captured at the moment of failure: the page accessibility tree, console output, and network logs
+* Historical pass/fail data and flakiness rates for the test
+* Run, spec, instance, and attempt identifiers the agent can use to query further details via [MCP](mcp-server.md)
+
+Every entry point below delivers this same context - they differ in where you are when you use them and how much of the loop is automated.
+
+## Entry points
+
+| Method                                                                    | Where                              | Best for                                                            |
+| ------------------------------------------------------------------------- | ---------------------------------- | ------------------------------------------------------------------- |
+| [MCP Server](mcp-server.md)                                               | Any MCP-capable agent              | Agents querying runs, tests, and analytics on demand; autonomous troubleshooting |
+| [IDE Extension](ide-extension.md)                                         | VS Code, Cursor, compatible forks  | Debugging CI failures without leaving the editor                    |
+| [Fix with AI](#fix-with-ai-from-the-dashboard)                            | Currents dashboard                 | Handing a failure to an agent while triaging a run                  |
+| [Playwright Skill](agent-skill-playwright-best-practices.md)              | Claude Code, Cursor, other agents  | Teaching agents how to write and fix Playwright tests correctly     |
+| [n8n](../resources/integrations/n8n.md)                                   | n8n workflows                      | Automated triage, notifications, and agent pipelines without code   |
+
+### MCP Server
+
+The [Currents MCP server](mcp-server.md) is the foundation the other entry points build on. It exposes tools for retrieving projects, runs, test results, spec instances, and performance analytics, so any MCP-capable agent - Claude Code, Cursor, or a custom agent built on the Model Context Protocol - can pull test data on demand instead of relying on what you paste into the prompt.
+
+This is what enables autonomous workflows: an agent given a run ID can enumerate the failures, fetch each test's error details and history, decide which failures share a root cause, and iterate on a fix - querying for more context as it goes rather than working from a fixed snapshot.
+
+Access is scoped by the API key you configure. Use a **Read Only** key when the agent only needs to read results; a **Read & Write** key additionally allows operations like canceling runs or managing webhooks, including some irreversible deletions. See [MCP Server](mcp-server.md) for the permission model and [API Keys](../dashboard/administration/api-keys.md) for creating scoped keys.
+
+### IDE Extension
+
+The [IDE extension](ide-extension.md) brings CI runs, failure details, and flaky test analytics into VS Code, Cursor, and other compatible editors. Its **Fix with agent** actions assemble the full troubleshooting context - the processed error, test history, and the error-context snapshot - and hand it to your editor's AI assistant, scoped to a single test, a spec file, or all failures in a run.
+
+The extension also registers the Currents MCP server automatically, so the agent can follow up with its own queries after the initial prompt. An **Analyze with Currents** action on every test definition pulls recent failure and flakiness data for that specific test - useful for investigating a test before it becomes a problem, not just after it fails.
+
+This is the fastest interactive loop: failure feed, trace viewer, source code, and agent all in one place.
+
+### Fix with AI from the dashboard
+
+When you're triaging a run in the dashboard, every failed test attempt has a **Fix with AI** action. It generates a prompt containing the processed error, code frame, a link to the error-context snapshot, and the MCP identifiers (project, run, instance, test, attempt) an agent needs to fetch deeper context.
+
+You can copy the prompt to your clipboard for any agent, or open it directly in a supported tool - Cursor, GitHub Copilot, Claude Code, Zed, Conductor, or Codex. The dashboard remembers your preferred target.
+
+This is the bridge from investigation to action: whoever is looking at the failing run - not necessarily the person with the repo open - can package the failure with its full context and route it to an agent in one click.
+
+### Playwright Skill
+
+Context tells an agent *what* failed; the [Playwright Best Practices skill](agent-skill-playwright-best-practices.md) tells it *how* to fix it well. It's an [Agent Skill](https://agentskills.io/home) - an open standard supported by Claude Code, Cursor, VS Code, and others - that packages expert Playwright knowledge: locator strategy, web-first assertions, debugging flaky tests, CI configuration, and more.
+
+Without it, agents fall back on generic patterns from training data - sprinkling `waitForTimeout` calls, brittle CSS selectors, retries that mask real bugs. With it, fixes follow the same practices an experienced Playwright engineer would apply. Install it alongside any of the entry points above; the agent picks it up automatically when a task involves Playwright.
+
+```bash
+npx skills add https://github.com/currents-dev/playwright-best-practices-skill
+```
+
+### n8n
+
+The [n8n integration](../resources/integrations/n8n.md) connects Currents to 1,300+ apps for workflows that run without a human in the loop. The Currents n8n node reads runs and test results via the API, so you can build automations that react to test outcomes: route new failures to Slack with context attached, open tickets for tests that cross a flakiness threshold, or feed failure data to an AI agent node for automated analysis and triage.
+
+Combined with [HTTP webhooks](../resources/integrations/http-webhooks.md) as a trigger, this covers the fully autonomous end of the spectrum - no editor, no dashboard, just test results flowing into whatever process you define.
+
+## Combining entry points
+
+These methods compose - most teams end up using several:
+
+* **Interactive debugging**: the IDE extension for the failure feed and one-click fixes, with the MCP server (auto-registered) letting the agent query beyond the initial prompt, and the Playwright skill shaping the fixes it writes.
+* **Triage to fix**: whoever monitors the dashboard uses Fix with AI to package failures for the engineer's agent of choice - the MCP identifiers in the prompt let that agent pick up the investigation with full access to the run.
+* **Autonomous troubleshooting**: an n8n workflow or webhook triggers on run completion, an agent with the MCP server and the Playwright skill analyzes the failures, and the output is a draft fix, a triaged ticket, or a root-cause summary - before anyone looks at the run.

--- a/ai/README.md
+++ b/ai/README.md
@@ -92,7 +92,7 @@ This is the bridge from investigation to action: whoever is looking at the faili
 
 Context tells an agent *what* failed; the [Playwright Best Practices skill](agent-skill-playwright-best-practices.md) tells it *how* to fix it well. It's an [Agent Skill](https://agentskills.io/home) - an open standard supported by Claude Code, Cursor, VS Code, and others - that packages expert Playwright knowledge: locator strategy, web-first assertions, debugging flaky tests, CI configuration, and more.
 
-It is the most-installed Playwright skill on [skills.sh](https://skills.sh) with 64K+ installs, ranking second among all skills for the "playwright" keyword.
+As of July 2026, it is the most-installed Playwright skill on [skills.sh](https://skills.sh) - over 64K installs - and the second-ranked result among all skills for the "playwright" keyword.
 
 Without it, agents fall back on generic patterns from training data - sprinkling `waitForTimeout` calls, brittle CSS selectors, retries that mask real bugs. With it, fixes follow the same practices an experienced Playwright engineer would apply. Install it alongside any of the entry points above; the agent picks it up automatically when a task involves Playwright.
 
@@ -102,7 +102,7 @@ npx skills add https://github.com/currents-dev/playwright-best-practices-skill
 
 ### n8n
 
-The [n8n integration](../resources/integrations/n8n.md) connects Currents to 1,300+ apps for workflows that run without a human in the loop. The Currents n8n node reads runs and test results via the API, so you can build automations that react to test outcomes: route new failures to Slack with context attached, open tickets for tests that cross a flakiness threshold, or feed failure data to an AI agent node for automated analysis and triage.
+The [n8n integration](../resources/integrations/n8n.md) connects Currents to more than a thousand apps for workflows that run without a human in the loop. The Currents n8n node reads runs and test results via the API, so you can build automations that react to test outcomes: route new failures to Slack with context attached, open tickets for tests that cross a flakiness threshold, or feed failure data to an AI agent node for automated analysis and triage.
 
 Combined with [HTTP webhooks](../resources/integrations/http-webhooks.md) as a trigger, this covers the fully autonomous end of the spectrum - no editor, no dashboard, just test results flowing into whatever process you define.
 

--- a/ai/README.md
+++ b/ai/README.md
@@ -1,17 +1,19 @@
 ---
 description: >-
-  How to connect AI agents to Currents test results - MCP, IDE extension,
-  dashboard prompts, agent skills, and automation
+  Fix and auto-heal failing Playwright tests in CI with AI agents - MCP server,
+  IDE extension, dashboard prompts, agent skills, and automation
 icon: sparkles
 ---
 
-# Overview
+# Fix Playwright CI Failures with AI
 
-Currents captures everything about your test runs: errors, stack traces, traces, console and network logs, historical pass/fail data, flakiness rates, and performance metrics. This page is an overview of the ways to put that data in front of an AI agent - whether you are debugging interactively in your editor, triaging failures from the dashboard, or building autonomous troubleshooting pipelines.
+Currents captures everything about your Playwright test runs in CI: errors, stack traces, traces, console and network logs, historical pass/fail data, flakiness rates, and performance metrics. This page is an overview of the ways to put that data in front of an AI agent - whether you are debugging interactively in your editor, triaging failures from the dashboard, or building pipelines that auto-heal failing tests before anyone looks at the run.
+
+<!-- IMAGE PLACEHOLDER: infographic — "CI run → Currents context layer → AI agents". Left: a CI run producing failures; center: the Currents context package (error, trace, history, flakiness, error-context snapshot); right: the five entry points fanning out (MCP, IDE, dashboard, skill, n8n). This is the anchor visual for the whole page. -->
 
 ## Why context matters
 
-Pasting an error message into an AI chat is the least effective way to use an agent for test failures. The error message alone is missing most of what determines the right fix:
+Pasting an error message into an AI chat is the least effective way to get an AI fix for a Playwright test failure. The error message alone is missing most of what determines the right fix:
 
 * Is this test flaky, or did it just start failing? An agent that doesn't know the test's history will "fix" a flaky test by treating a symptom.
 * What was on the page when the assertion failed? Without the DOM state, the agent guesses why a locator didn't match.
@@ -23,6 +25,8 @@ Currents post-processes test results on the server into a structured troubleshoo
 * An **error-context snapshot** captured at the moment of failure: the page accessibility tree, console output, and network logs
 * Historical pass/fail data and flakiness rates for the test
 * Run, spec, instance, and attempt identifiers the agent can use to query further details via [MCP](mcp-server.md)
+
+<!-- IMAGE PLACEHOLDER: side-by-side comparison — a raw CI error message pasted into a chat (left) vs. the Currents enriched prompt with error, code frame, history, and error-context snapshot (right). Annotate what the raw version is missing. -->
 
 Every entry point below delivers this same context - they differ in where you are when you use them and how much of the loop is automated.
 
@@ -40,13 +44,35 @@ Every entry point below delivers this same context - they differ in where you ar
 
 The [Currents MCP server](mcp-server.md) is the foundation the other entry points build on. It exposes tools for retrieving projects, runs, test results, spec instances, and performance analytics, so any MCP-capable agent - Claude Code, Cursor, or a custom agent built on the Model Context Protocol - can pull test data on demand instead of relying on what you paste into the prompt.
 
-This is what enables autonomous workflows: an agent given a run ID can enumerate the failures, fetch each test's error details and history, decide which failures share a root cause, and iterate on a fix - querying for more context as it goes rather than working from a fixed snapshot.
+This is what makes auto-healing possible rather than one-shot fixes: an agent given a run ID can enumerate the failures, fetch each test's error details and history, decide which failures share a root cause, implement a fix, and verify it - querying for more context at every step instead of working from a fixed snapshot.
+
+<!-- IMAGE PLACEHOLDER: screenshot or terminal recording — an agent session (e.g. Claude Code) calling Currents MCP tools: fetching a run, listing failed tests, pulling an error-context snapshot, then editing a spec file. Even a static screenshot of the tool-call transcript works. -->
+
+What agents accomplish with the MCP server in practice:
+
+* **Failure triage** - summarize a run, group failures by root cause, and separate new regressions from known flaky tests
+* **AI fixes with verification** - fix a failing test, then check the next run's results to confirm the fix held
+* **Flakiness burn-down** - rank tests by flakiness over a date range and work through them systematically
+* **Performance investigation** - find the slowest specs and tests, and track duration changes across runs
+* **Cross-run analysis** - answer "when did this start failing?" or "does this fail on every branch or just mine?" from run history
+
+Example prompts:
+
+* "Tests are failing in CI. Get the details for run `<runId>` and fix the failures."
+* "Summarize the last run - group the failures by likely root cause and tell me which are new versus known flaky."
+* "What were the top flaky tests in the last 30 days? Fix the three worst ones."
+* "What are the slowest specs in the last 7 days? Suggest what to split or parallelize."
+* "When did `checkout.spec.ts` start failing, and what changed in its error message between runs?"
+
+The Currents MCP server pairs well with browser-automation MCP servers such as [Playwright MCP](https://github.com/microsoft/playwright-mcp): Currents supplies what failed in CI and why, and the browser tools let the agent reproduce the failure in a live browser before committing a fix.
 
 Access is scoped by the API key you configure. Use a **Read Only** key when the agent only needs to read results; a **Read & Write** key additionally allows operations like canceling runs or managing webhooks, including some irreversible deletions. See [MCP Server](mcp-server.md) for the permission model and [API Keys](../dashboard/administration/api-keys.md) for creating scoped keys.
 
 ### IDE Extension
 
 The [IDE extension](ide-extension.md) brings CI runs, failure details, and flaky test analytics into VS Code, Cursor, and other compatible editors. Its **Fix with agent** actions assemble the full troubleshooting context - the processed error, test history, and the error-context snapshot - and hand it to your editor's AI assistant, scoped to a single test, a spec file, or all failures in a run.
+
+<!-- IMAGE PLACEHOLDER: screenshot — the Run Details panel with the "Fix all failures" / "Fix with agent" buttons visible next to a failed test. Reuse or re-crop an asset from ide-extension.md if a dedicated capture isn't available. -->
 
 The extension also registers the Currents MCP server automatically, so the agent can follow up with its own queries after the initial prompt. An **Analyze with Currents** action on every test definition pulls recent failure and flakiness data for that specific test - useful for investigating a test before it becomes a problem, not just after it fails.
 
@@ -58,11 +84,15 @@ When you're triaging a run in the dashboard, every failed test attempt has a **F
 
 You can copy the prompt to your clipboard for any agent, or open it directly in a supported tool - Cursor, GitHub Copilot, Claude Code, Zed, Conductor, or Codex. The dashboard remembers your preferred target.
 
+<!-- IMAGE PLACEHOLDER: screenshot — a failed test attempt in the dashboard test sidebar with the Fix with AI button open, showing the provider menu (Copy as Prompt, Fix with Cursor, Fix with Claude Code, ...). -->
+
 This is the bridge from investigation to action: whoever is looking at the failing run - not necessarily the person with the repo open - can package the failure with its full context and route it to an agent in one click.
 
 ### Playwright Skill
 
 Context tells an agent *what* failed; the [Playwright Best Practices skill](agent-skill-playwright-best-practices.md) tells it *how* to fix it well. It's an [Agent Skill](https://agentskills.io/home) - an open standard supported by Claude Code, Cursor, VS Code, and others - that packages expert Playwright knowledge: locator strategy, web-first assertions, debugging flaky tests, CI configuration, and more.
+
+It is the most-installed Playwright skill on [skills.sh](https://skills.sh) with 64K+ installs, ranking second among all skills for the "playwright" keyword.
 
 Without it, agents fall back on generic patterns from training data - sprinkling `waitForTimeout` calls, brittle CSS selectors, retries that mask real bugs. With it, fixes follow the same practices an experienced Playwright engineer would apply. Install it alongside any of the entry points above; the agent picks it up automatically when a task involves Playwright.
 
@@ -76,11 +106,15 @@ The [n8n integration](../resources/integrations/n8n.md) connects Currents to 1,3
 
 Combined with [HTTP webhooks](../resources/integrations/http-webhooks.md) as a trigger, this covers the fully autonomous end of the spectrum - no editor, no dashboard, just test results flowing into whatever process you define.
 
+<!-- IMAGE PLACEHOLDER: diagram — an n8n canvas: Currents webhook trigger → filter (failed runs) → AI agent node with Currents context → Slack message / GitHub PR / Jira ticket outputs. -->
+
 ## Coming up
 
 ### Slack
 
 **Fix with AI** is coming to the [Slack integration](../resources/integrations/slack/README.md): failed-test notifications will include a Fix with AI button that opens one-click deep links to AI coding tools, plus a copyable prompt for everything else - prefilled with the same enriched failure context and MCP identifiers as the dashboard and IDE actions. A failure lands in your team channel, and anyone in the thread can route it to an agent without opening the dashboard first.
+
+<!-- IMAGE PLACEHOLDER: screenshot or mockup — a Slack failed-test notification with the Fix with AI button, and the modal it opens with provider deep links and the copyable prompt. Capture from staging once ENG-847 lands. -->
 
 ## Combining entry points
 
@@ -88,4 +122,4 @@ These methods compose - most teams end up using several:
 
 * **Interactive debugging**: the IDE extension for the failure feed and one-click fixes, with the MCP server (auto-registered) letting the agent query beyond the initial prompt, and the Playwright skill shaping the fixes it writes.
 * **Triage to fix**: whoever monitors the dashboard uses Fix with AI to package failures for the engineer's agent of choice - the MCP identifiers in the prompt let that agent pick up the investigation with full access to the run.
-* **Autonomous troubleshooting**: an n8n workflow or webhook triggers on run completion, an agent with the MCP server and the Playwright skill analyzes the failures, and the output is a draft fix, a triaged ticket, or a root-cause summary - before anyone looks at the run.
+* **Auto-healing CI**: an n8n workflow or webhook triggers on run completion, an agent with the MCP server and the Playwright skill analyzes the failures and drafts a fix - a triaged ticket, a root-cause summary, or a PR that heals the failing test before anyone opens the run.


### PR DESCRIPTION
## What

Adds an overview guide as the AI section landing page (`ai/README.md`, registered first in the AI section of `SUMMARY.md`).

## Why

The AI section had three standalone pages but no page explaining how they relate or which to pick. This guide:

- Covers all five ways to use Currents with AI agents: MCP server, IDE extension, dashboard **Fix with AI**, Playwright Best Practices skill, and n8n
- Explains what the server-processed troubleshooting context includes (error + stack trace + code frame, error-context snapshot, test history, MCP identifiers) and why it's more effective than pasting a raw error message
- Shows how the entry points compose: interactive debugging in the editor, dashboard triage → agent handoff, and fully autonomous troubleshooting pipelines

## Notes

- **Fix with AI** (dashboard) had no doc page; its section here is currently its only documentation. It's written from the dashboard implementation (`useAiFixActions.tsx` / `aiFixPrompt.ts`), including the supported deep-link targets (Cursor, GitHub Copilot, Claude Code, Zed, Conductor, Codex). If that vendor list is expected to churn, it can be generalized.
- All internal links point to existing pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LPJDew9moPTh1BzD2pYXyU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an AI “Overview” entry to the documentation table of contents.
  * Introduced a new AI documentation page explaining how to use Currents’ structured Playwright CI troubleshooting context with AI agents.
  * Expanded coverage of AI entry points, including Currents MCP Server, IDE “Fix with agent,” dashboard “Fix with AI,” Playwright best-practices assistance, and n8n-based triage workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->