### PR TITLE
Add redirects for the 404s left after #63

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -68,3 +68,15 @@ redirects:
   getting-started/ci-setup/aws-code-build: getting-started/ci-setup/playwright-aws-code-build.md
   getting-started/ci-setup/bitbucket: getting-started/other-frameworks/cypress/ci-setup/cypress-bitbucket-pipelines.md
   getting-started/ci-setup/nx/playwright-nx: getting-started/ci-setup/nx.md
+  ci-setup/circleci: getting-started/ci-setup/playwright-circleci.md
+  ci-setup/azure-devops: getting-started/ci-setup/playwright-azure-devops.md
+  ci-setup/bitbucket: getting-started/other-frameworks/cypress/ci-setup/cypress-bitbucket-pipelines.md
+  ci-setup/jenkins-playwright: getting-started/ci-setup/jenkins.md
+  guides/currents-cli: resources/reporters/currents-cli.md
+  guides/cypress-11: getting-started/other-frameworks/cypress/integrating-with-cypress/compatibility.md
+  guides/parallelization-guide/cypress-parallelization: getting-started/other-frameworks/cypress/README.md
+  guides/ci-optimization/re-run-only-failed-tests/re-run-only-failed-tests-orchestrated: guides/ci-optimization/re-run-only-failed-tests-orchestrated-v2.md
+  integrations/jira/projects: resources/integrations/jira.md
+  projects: dashboard/projects/README.md
+  webhooks: resources/integrations/http-webhooks.md
+  actions: guides/currents-actions/README.md


### PR DESCRIPTION
# User description
> **Stacked on #63** — based on `fix/broken-links-and-redirects`, so the diff shows only the 12 new entries. Merge #63 first, then this retargets to `main` automatically.

## What

Twelve `.gitbook.yaml` redirect entries for URLs that still hard-404.

## Why

Search Console reports **91 crawled 404s on `docs.currents.dev`**. #63 already covers ten that are real page moves. These are the remainder — including every path still reachable from `currents.dev/readme/*`, which is being converted from a proxy rewrite to a 301 in currents-dev/www.currents.dev#250.

**Bare CI-provider paths** (4) — predate flattening the `ci-setup` tree:

```
ci-setup/circleci           -> getting-started/ci-setup/playwright-circleci.md
ci-setup/azure-devops       -> getting-started/ci-setup/playwright-azure-devops.md
ci-setup/bitbucket          -> .../cypress/ci-setup/cypress-bitbucket-pipelines.md
ci-setup/jenkins-playwright -> getting-started/ci-setup/jenkins.md
```

Files with those names still exist at the repo root but are **absent from `SUMMARY.md`**, so GitBook doesn't serve them — which is why they 404. These entries are additive and leave the files alone. Whether that unlisted `ci-setup/` directory should exist at all is a separate question; `ci-setup/jenkins-playwright.md` is 76 lines of real content, so I didn't touch it.

**Pages that moved section** (8) — `currents-cli` to `resources/reporters`, `jira` to `resources/integrations`, `currents-actions` and the orchestrated re-run guide to their current homes, plus `projects`, `webhooks`, `actions`.

## Verification

Every target URL returns 200 on `docs.currents.dev`:

```
/getting-started/ci-setup/playwright-circleci                200
/getting-started/ci-setup/playwright-azure-devops            200
/getting-started/ci-setup/jenkins                            200
/resources/reporters/currents-cli                            200
/resources/integrations/jira                                 200
/dashboard/projects                                          200
/resources/integrations/http-webhooks                        200
/guides/currents-actions                                     200
/guides/ci-optimization/re-run-only-failed-tests-orchestrated-v2  200
...
```

YAML parses. All 79 targets exist on disk. No duplicate keys.

## Not fixed here — 60 of the 91 docs 404s are a GitBook bug

Two-thirds of the docs 404s are `<page>/rss.xml`. GitBook emits this on **every** page:

```html
<link rel="alternate" type="application/rss+xml"
      href="https://docs.currents.dev/guides/record-key/rss.xml" title="RSS Feed"/>
```

No feed exists at that path, or at `/rss.xml`. Google follows the link and records a 404, once per page. Nothing in this repo controls that markup — it needs a GitBook support ticket, not a redirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013vBAvmWyyJsE1eTnxXL2XP

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add twelve GitBook redirect entries to route remaining hard-404 documentation URLs to their current pages. Update the <code>.gitbook.yaml</code> redirect configuration to cover relocated CI setup, integration, dashboard, reporter, and guide content while preserving existing source files.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/currents-dev/currents-readme/64?tool=ast&topic=Product+page+redirects>Product page redirects</a>
        </td><td>Redirect remaining top-level product pages such as <code>projects</code>, <code>webhooks</code>, and <code>actions</code> to their current dashboard, integration, and guide locations.<details><summary>Modified files (1)</summary><ul><li>.gitbook.yaml</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>agoldis@users.noreply....</td><td>Fix broken redirects a...</td><td>August 08, 2026</td></tr>
<tr><td>agoldis@gmail.com</td><td>Add redirects for the ...</td><td>August 08, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/currents-dev/currents-readme/64?tool=ast&topic=Documentation+redirects>Documentation redirects</a>
        </td><td>Add redirects for legacy CI setup paths and relocated documentation, including <code>currents-cli</code>, Jira, Cypress compatibility, parallelization, and rerun guides.<details><summary>Modified files (1)</summary><ul><li>.gitbook.yaml</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>agoldis@users.noreply....</td><td>Fix broken redirects a...</td><td>August 08, 2026</td></tr>
<tr><td>agoldis@gmail.com</td><td>Add redirects for the ...</td><td>August 08, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/currents-dev/currents-readme/64?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added redirects for updated documentation paths covering integrations, CLI usage, Cypress, reruns, Jira, projects, webhooks, and automation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->